### PR TITLE
Updated file location for LB2

### DIFF
--- a/doc_posts/_faq-general/install-extension.md
+++ b/doc_posts/_faq-general/install-extension.md
@@ -34,6 +34,6 @@ Extension developers can choose to protect their extension decks and their butto
 
 #### Create an extension
 Lioranboard communicates with all its extensions via transmitter.html and its own websocket.\
-Information about how to make your own extension can be found in `LioranBoard/extension/how to make extensions.txt` file.\
+Information about how to make your own extension can be found in `LioranBoard2/transmitter/how to make extensions.txt` file.\
 Knowledge of JavaScript programming and LioranBoard variable handling is a requirement to program extensions.  We encourage you to go over some existing extensions to understand the process.\
 Once you have an extension working, you can submit it in *#development* channel in the official [LioranBoard Discord server](https://discord.gg/dXez8Zh). You will need one of the mods to approve it before it can be officially released. Use our [Extension Submission Form](https://lioranboard.ca/extensions/submit) if you want your extension to be posted on the official LioranBoard website. 


### PR DESCRIPTION
File location for 'how to make extensions.txt' was pointing to LioranBoard/extension. This location changed in LB2.