### PR TITLE
Update naming from lioranboard to SAMMI

### DIFF
--- a/doc_posts/_commands-array/array-parse.md
+++ b/doc_posts/_commands-array/array-parse.md
@@ -3,19 +3,19 @@ title: "Parse Array/Object"
 num: 10
 ---
 
-Turns a JSON string into an array/object. Must be properly formatted (LioranBoard will give you a warning if it finds any formatting errors).\
+Turns a JSON string into an array/object. Must be properly formatted (SAMMI will give you a warning if it finds any formatting errors).\
 This way you can easily create a prepopulated object/array, as it supports nesting.\
 Read more about JSON syntax at [w3schools.com](https://www.w3schools.com/js/js_json_syntax.asp).
 
-{% include alert.html text="Parsing an array that's directly within another array is not supported." type="warning" %} 
+{% include alert.html text="Parsing an array that's directly within another array is not supported." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Array/Object Name	| String | Name of the variable to save the parsed array/object into
 |String Array/JSON	| JSON String | JSON string to parse
 {:class='table table-primary'}
 
-| JSON string before conversion|  Result saved in the variable|  
+| JSON string before conversion|  Result saved in the variable|
 |-------|--------|
 | {% include selectAll.html text='<code>["Lioran", "Melonax", "Cyanidesugar"]</code>' %}   | {% include image_table.html w="50" src="arrInsert.png" alt="Parsed JSON string" %} |
 | {% include selectAll.html text='<code>["Hello", "Hi", {"MyObject": [1, 2, 3]}]</code>' %}   | {% include video_span.html w="50" src="arrInsert1.mp4" alt="Parsed JSON string" %} |

--- a/doc_posts/_commands-buffer/buffer-create.md
+++ b/doc_posts/_commands-buffer/buffer-create.md
@@ -5,20 +5,20 @@ num: 1
 
 Creates a new buffer with the given name.
 
-{% include alert.html text="You must delete a buffer before creating another one with the same name." type="warning" %} 
+{% include alert.html text="You must delete a buffer before creating another one with the same name." type="warning" %}
 
 When creating a buffer, you should always try to create it to a size that is appropriate to the type, with the general rule being that it should be created to accommodate the maximum size of data that it is to store.
 
-**Buffer types:** 
-- Fixed - A buffer of a fixed size in bytes. The size is set when the buffer is created and cannot be changed again. LioranBoard will crash when you reach the limit size. 
-- buffExpand With Grow - A buffer that will grow dynamically as data is added. You create it with an initial size (which should be an approximation of the size of the data expected to be stored), and then it will expand to accept further data that overflows this initial size. 
+**Buffer types:**
+- Fixed - A buffer of a fixed size in bytes. The size is set when the buffer is created and cannot be changed again. SAMMI will crash when you reach the limit size.
+- buffExpand With Grow - A buffer that will grow dynamically as data is added. You create it with an initial size (which should be an approximation of the size of the data expected to be stored), and then it will expand to accept further data that overflows this initial size.
 - Wrap - A buffer where the data will wrap. When the data being added reaches the limit of the buffer size, the overwrite will be placed back at the start of the buffer, and further writing will continue from that point.
 
 {% include image.html w="200px" src="Buffer_Types.png" alt="Buffer types" %}
 
-{% include alert.html text="If in doubt, use a grow buffer to prevent overwrite errors." type="info" %} 
+{% include alert.html text="If in doubt, use a grow buffer to prevent overwrite errors." type="info" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Buffer Name	|String	| Name of the buffer to create
 |Byte Size | Size of the buffer in bytes. |

--- a/doc_posts/_commands-buffer/buffer-delete.md
+++ b/doc_posts/_commands-buffer/buffer-delete.md
@@ -5,9 +5,9 @@ num: 5
 
 Deletes a buffer you created or loaded, releasing the resources used to create it and removing any data that it may currently contain.
 
-{% include alert.html text="If you try to delete a non existing buffer, LioranBoard will crash. Use Buffer: Exists command first." type="danger" %} 
+{% include alert.html text="If you try to delete a non existing buffer, SAMMI will crash. Use Buffer: Exists command first." type="danger" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Buffer Name	|String	| Name of the buffer
 {:class='table table-primary'}

--- a/doc_posts/_commands-buffer/buffer-exists.md
+++ b/doc_posts/_commands-buffer/buffer-exists.md
@@ -4,14 +4,14 @@ num: 10
 ---
 
 Check if a buffer exists and save the result in a variable.\
-Use this command before using Buffer: Delete command, as it will crash LioranBoard if you try to delete a non existing buffer.
+Use this command before using Buffer: Delete command, as it will crash SAMMI if you try to delete a non existing buffer.
 
 **Result:**
 - 0 - Buffer doesn't exist
 - 1 - Buffer exists
 
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Buffer Name	|String	| Name of the buffer
 |Variable|String|Variable to save the result in.

--- a/doc_posts/_commands-buffer/buffer-introduction.md
+++ b/doc_posts/_commands-buffer/buffer-introduction.md
@@ -8,14 +8,14 @@ A buffer is basically a space within the system memory that is used to store sma
 
 {% include image.html w="75" src="Buffer_Memory.png" alt="Buffer within memory" %}
 
-You can save and load *ANY* file into a buffer in LioranBoard, which is the best part about having buffer commands!\
-For example, LioranBoard does not natively support text files, but that's okay, because you can simply load, read and save any text file using buffers instead!
+You can save and load *ANY* file into a buffer in SAMMI, which is the best part about having buffer commands!\
+For example, SAMMI does not natively support text files, but that's okay, because you can simply load, read and save any text file using buffers instead!
 
-{% include alert.html text="A buffer will exist until you either manually delete it or restart LioranBoard." type="warning" %} 
+{% include alert.html text="A buffer will exist until you either manually delete it or restart SAMMI." type="warning" %}
 
-**Data Types** 
+**Data Types**
 
-| Buffer Type | Description | 
+| Buffer Type | Description |
 |-------|--------
 | Unsigned 8bits | A single byte value. This is a positive value from 0 to 255.
 | Signed 8bits | A single byte value. This can be a positive or negative value from -128 to 127 (0 is classed as positive).

--- a/doc_posts/_commands-buffer/buffer-poke.md
+++ b/doc_posts/_commands-buffer/buffer-poke.md
@@ -7,9 +7,9 @@ Writes data to a buffer at the specified position.
 
 Writing data to a buffer will advance the position of the head by however many bytes it wrote.
 
-{% include alert.html text="LioranBoard will crash when you try to write data to a fixed buffer with a position larger than the buffer size." type="danger" %} 
+{% include alert.html text="SAMMI will crash when you try to write data to a fixed buffer with a position larger than the buffer size." type="danger" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Buffer Name	|String	| Name of the buffer
 |Type	|Dropdown	| Type of the buffer

--- a/doc_posts/_commands-buffer/buffer-write.md
+++ b/doc_posts/_commands-buffer/buffer-write.md
@@ -7,9 +7,9 @@ Writes data to a buffer at the position of the read/write head.
 
 Writing data to a buffer will advance the position of the head by however many bytes it wrote.
 
-{% include alert.html text="LioranBoard will crash when you try to write data to a fixed buffer with a position larger than the buffer size." type="danger" %} 
+{% include alert.html text="SAMMI will crash when you try to write data to a fixed buffer with a position larger than the buffer size." type="danger" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Buffer Name	|String	| Name of the buffer
 |Type	|Dropdown	| Type of the buffer

--- a/doc_posts/_commands-button/button-block.md
+++ b/doc_posts/_commands-button/button-block.md
@@ -5,15 +5,15 @@ num: 3
 
 Blocks or unblocks a button/group by its ID.\
 Won't cancel an ongoing button/group but will prevent any already existing queue from happening when its turn comes.\
-The block does not persist when LioranBoard is restarted.\
+The block does not persist when SAMMI is restarted.\
 By setting the ID to all you can remove all current blocks. This only works for unblocking buttons.
 
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Button ID/Group ID|	Any|	Button ID or Group ID to block/unblock
 |Block|	Checkbox	|**Checked** = block a button, **Unchecked** = unblock a button
-|Allow Queue|	Checkbox	|**Checked** = queue will wait for button to be unblocked and then will continue as normal <br/> **Unchecked** =  any queue when the button is blocked will be ignored and deleted 
+|Allow Queue|	Checkbox	|**Checked** = queue will wait for button to be unblocked and then will continue as normal <br/> **Unchecked** =  any queue when the button is blocked will be ignored and deleted
 {:class='table table-primary'}
 
 

--- a/doc_posts/_commands-file-csv/csv delete.md
+++ b/doc_posts/_commands-file-csv/csv delete.md
@@ -3,9 +3,9 @@ title: "CSV Delete"
 num: 4
 ---
 
-Deletes a CSV file that was previously loaded. This does NOT delete the CSV file from where it is saved to, it merely deletes the CSV data from the buffer space withn LioranBoard. A CSV file that has been loaded cannot be loaded again unless the CSV has been deleted from the buffer space.  
+Deletes a CSV file that was previously loaded. This does NOT delete the CSV file from where it is saved to, it merely deletes the CSV data from the buffer space withn SAMMI. A CSV file that has been loaded cannot be loaded again unless the CSV has been deleted from the buffer space.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |CSV Name|String|Name of your CSV
 {:class='table table-primary'}

--- a/doc_posts/_commands-file-csv/csv-column-find.md
+++ b/doc_posts/_commands-file-csv/csv-column-find.md
@@ -4,9 +4,9 @@ num: 19
 ---
 
 Finds a value in a specified column. The first box underneath the column title will return a position of '0', and the numbers will increase as you go down the column.
-LioranBoard will return a value of -1 if no match is found in the column.
+SAMMI will return a value of -1 if no match is found in the column.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |CSV Name|String|Name of your CSV
 |Column Name/Number|String|Name of the column to search in

--- a/doc_posts/_commands-file-csv/csv-exists.md
+++ b/doc_posts/_commands-file-csv/csv-exists.md
@@ -3,9 +3,9 @@ title: "CSV Exists"
 num: 5
 ---
 
-Checks to see if a CSV file exists. LioranBoard will return a result of "true" if the variable exists, and "false" if it does not.
+Checks to see if a CSV file exists. SAMMI will return a result of "true" if the variable exists, and "false" if it does not.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------|
 |CSV Name|String|Name of your CSV
 |Save Variable As|String|Variable to save the result as

--- a/doc_posts/_commands-file-csv/csv-get-size.md
+++ b/doc_posts/_commands-file-csv/csv-get-size.md
@@ -3,9 +3,9 @@ title: "CSV Get Size"
 num: 6
 ---
 
-Gets the size of either rows or columns in a specified CSV file. LioranBoard returns the size as a real number. 
+Gets the size of either rows or columns in a specified CSV file. SAMMI returns the size as a real number.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------|
 |CSV Name|String|Name of your CSV
 |Save Variable As|String|Variable to save the result as

--- a/doc_posts/_commands-file-csv/csv-row-find.md
+++ b/doc_posts/_commands-file-csv/csv-row-find.md
@@ -4,9 +4,9 @@ num: 20
 ---
 
 Finds a value in a specified row. The left-most box in a row will return a position of '0', and the numbers will increase as you go right along the row.
-LioranBoard will return the position of the value in the row if a match is found. A value of -1 if no match is found in the row.
+SAMMI will return the position of the value in the row if a match is found. A value of -1 if no match is found in the row.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |CSV Name|String|Name of your CSV
 |Row Name/Number|String|Name/Number of the row to search in

--- a/doc_posts/_commands-file-csv/csv-save.md
+++ b/doc_posts/_commands-file-csv/csv-save.md
@@ -3,19 +3,19 @@ title: "CSV Save"
 num: 2
 ---
 
-Saves your CSV file to a file path of your choice. The file path has to be the full file path of the file, ending with .csv, and currently works best if drive letters are in lowercase. Alternatively, you can use the `/$global.main_directory$/` variable to save your CSV to the default directory. 
+Saves your CSV file to a file path of your choice. The file path has to be the full file path of the file, ending with .csv, and currently works best if drive letters are in lowercase. Alternatively, you can use the `/$global.main_directory$/` variable to save your CSV to the default directory.
 
-When a CSV file is saved, an extra row appears at the bottom of the file that is used to save your default values. Modifying this extra row may result in your default values not being read properly by LioranBoard, and your CSV being corrupted. 
+When a CSV file is saved, an extra row appears at the bottom of the file that is used to save your default values. Modifying this extra row may result in your default values not being read properly by SAMMI, and your CSV being corrupted.
 
 Note that the file path uses a forward slash instead of the Windows default back slash.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |CSV Name|String|Name of your CSV.
 |File Path|String|File path to save to.
 {:class='table table-primary'}
 
-{% include example_public.html src="https://i.imgur.com/pqisayY.png" size="100" title="Save CSV file to default category" pastebin="mCDFXQJG" %} 
+{% include example_public.html src="https://i.imgur.com/pqisayY.png" size="100" title="Save CSV file to default category" pastebin="mCDFXQJG" %}
 
 
 

--- a/doc_posts/_commands-file-csv/general.md
+++ b/doc_posts/_commands-file-csv/general.md
@@ -4,7 +4,7 @@ num: 0
 ---
 
 A CSV file is a delimited text file that uses a comma to separate values.\
-CSV files consist of data arranged in rows and columns and LioranBoard has the functionality to load, save, set, edit, and manipulate the values within these rows and columns. These values can be saved as variables to be used in any way you want within the LioranBoard environment.
+CSV files consist of data arranged in rows and columns. SAMMI has the functionality to load, save, set, edit, and manipulate the values within these rows and columns. These values can be saved as variables to be used in any way you want within the SAMMI environment.
 
 
 

--- a/doc_posts/_commands-file-general/file-copy.md
+++ b/doc_posts/_commands-file-general/file-copy.md
@@ -6,7 +6,7 @@ num: 1
 Copies a file from the LioranBoard folder and pastes it in any of its subfolders.\
 Will not replace the file if one with the same name is already present.\
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |File Path|String|Full path including the file name you wish to copy.|
 |Copy to|String|Where you want to copy the file. <br/> You can use `sound\` for sound folder and `image\` for image folder.

--- a/doc_posts/_commands-file-general/file-exists.md
+++ b/doc_posts/_commands-file-general/file-exists.md
@@ -3,9 +3,9 @@ title: "File Exists"
 num: 2
 ---
 
-Checks if a file already exists in a specified path. LioranBoard will return "true" if the file exists, and "false" if it doesn't
+Checks if a file already exists in a specified path. SAMMI will return "true" if the file exists, and "false" if it doesn't
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |File Path|String|Full path including the file name you wish to copy|
 |Save Variable As|String|The variable to save the return value as

--- a/doc_posts/_commands-file-general/file-introduction.md
+++ b/doc_posts/_commands-file-general/file-introduction.md
@@ -3,10 +3,10 @@ title: "Introduction"
 num: 0
 ---
 
-LioranBoard fully supports creating, reading, writing and modifying INI and CSV files.  
+SAMMI fully supports creating, reading, writing and modifying INI and CSV files.
 
 
-With [Buffer commands]({{ "commands/buffer#introduction" | relative_url }}), LioranBoard can create, read, write and modify any file as well, however it's not as straight forward as using INI/CSV commands and requires some further knowledge.
+With [Buffer commands]({{ "commands/buffer#introduction" | relative_url }}), SAMMI can create, read, write and modify any file as well, however it's not as straight forward as using INI/CSV commands and requires some further knowledge.
 
 
 

--- a/doc_posts/_commands-introduction/input-boxes.md
+++ b/doc_posts/_commands-introduction/input-boxes.md
@@ -3,12 +3,12 @@ title: Input Boxes
 num: 2
 ---
 
-When you start using commands in LioranBoard, you will notice that some parameter boxes have yellow color and some have white color.
+When you start using commands in SAMMI, you will notice that some parameter boxes have yellow color and some have white color.
 {% include image.html w="100" src="variable_box.png" alt="Different parameter box colors" %}
 
 It's extremely important to know the difference as you need to **format your input according to the color of the box**.
 
-| Operation | White Box| Yellow Box| 
+| Operation | White Box| Yellow Box|
 |-------|--------|--------
 |Inserting another variable | You must wrap other variables in */$$/*. <br/> `/$myVariable$/` | You can directly type another variable.<br/> `myVariable`
 |Inserting array value | You must wrap them in */$$/*. <br/> `/$myArray[0]$/` | You can directly insert them. <br/> `myArray[0]`

--- a/doc_posts/_commands-introduction/premade-variables.md
+++ b/doc_posts/_commands-introduction/premade-variables.md
@@ -7,20 +7,20 @@ The following premade/permanent global variables are accessible from all the but
 
 
 
-| Variable | Explanation|  
+| Variable | Explanation|
 |-------|--------|--------
 {% include selectAll.html text="transmitter_connected" %}| True if connected, false if not connected
 {% include selectAll.html text="twitch_chat_connected" %}| True if connected, false if not connected
-{% include selectAll.html text="twitch_client_id" %}| LioranBoard Twitch Client ID, used in Twitch API calls
-{% include selectAll.html text="main_directory" %}| Main directory where LioranBoard folder resides. Useful for extension makers to be able to easily copy files. 
-{% include selectAll.html text="Architecture" %}| Type of architecture you're on. x64 or x86. 
-{% include selectAll.html text="elapsed_time" %}| Elapsed time in seconds since you last started LioranBoard
+{% include selectAll.html text="twitch_client_id" %}| SAMMI Twitch Client ID, used in Twitch API calls
+{% include selectAll.html text="main_directory" %}| Main directory where LioranBoard folder resides. Useful for extension makers to be able to easily copy files.
+{% include selectAll.html text="Architecture" %}| Type of architecture you're on. x64 or x86.
+{% include selectAll.html text="elapsed_time" %}| Elapsed time in seconds since you last started SAMMI
 {% include selectAll.html text="since_2020" %}| Elapsed time in seconds since January 1st, 2020.
-{% include selectAll.html text="mouse_x" %}| Current x position of your mouse 
-{% include selectAll.html text="mouse_y" %}| Current y position of your mouse 
+{% include selectAll.html text="mouse_x" %}| Current x position of your mouse
+{% include selectAll.html text="mouse_y" %}| Current y position of your mouse
 {% include selectAll.html text="twitch_accounts" %}| Array of all linked Twitch account login names
-{% include selectAll.html text="Main" %}| An object containing information about your main OBS connection. 
-{% include selectAll.html text="Main.connected" %}| Whether LioranBoard is currently connected to your main OBS, true = connected, false = disconnected
+{% include selectAll.html text="Main" %}| An object containing information about your main OBS connection.
+{% include selectAll.html text="Main.connected" %}| Whether SAMMI is currently connected to your main OBS, true = connected, false = disconnected
 {% include selectAll.html text="Main.current_scene" %}| Current scene in your main OBS
 {% include selectAll.html text="Main.previous_scene" %}| Previous scene in your main OBS
 {% include selectAll.html text="administrator_mode" %}| True if running in Administrator mode

--- a/doc_posts/_commands-misc/command-line.md
+++ b/doc_posts/_commands-misc/command-line.md
@@ -4,13 +4,13 @@ num: 5
 ---
 
 Execute a command line command just like you do in Command Prompt. Only one line of code.\
-If LioranBoard is running as admin, commands you perform will also run as admin.\
+If SAMMI is running as admin, commands you perform will also run as admin.\
 If you want to execute more than one line of code or the command is not executed properly, convert it to a batch file and use Execute program command instead.
 
-{% include alert.html text="You can use <code>|clip</code> at the end of your command to copy the result to your clipboard and then use Load Clipboard command to load it into LioranBoard." type="info" %} 
+{% include alert.html text="You can use <code>|clip</code> at the end of your command to copy the result to your clipboard and then use Load Clipboard command to load it back into SAMMI." type="info" %}
 
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Command|	String	|Command you wish to execute.
 {:class='table table-primary'}

--- a/doc_posts/_commands-misc/execute-program.md
+++ b/doc_posts/_commands-misc/execute-program.md
@@ -4,9 +4,9 @@ num: 4
 ---
 
 Launches any program from your PC.\
-If LioranBoard is running as admin, any program you launch through this command will also run as admin.
+If SAMMI is running as admin, any program you launch through this command will also run as admin.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |File Path|	String|	Select a path to the .exe file you wish to run.
 {:class='table table-primary'}

--- a/doc_posts/_commands-misc/get-date.md
+++ b/doc_posts/_commands-misc/get-date.md
@@ -3,13 +3,13 @@ title: Get Date/Time
 num: 0.9
 ---
 
-Returns current date and/or time, depending on what you select.  
+Returns current date and/or time, depending on what you select.
 
-Regarding time, there are also two helpful global permanent variables you can use: 
-`global.elapsed_time` - the number of seconds that elapsed since you launched LioranBoard
+Regarding time, there are also two helpful global permanent variables you can use:
+`global.elapsed_time` - the number of seconds that elapsed since you launched SAMMI
 `global.since_2020` - the number of seconds that elapsed since January 1st, 2020
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Variable|	String|	Variable to save the string in
 |Year| Checkbox| Include the year|

--- a/doc_posts/_commands-misc/popup-message.md
+++ b/doc_posts/_commands-misc/popup-message.md
@@ -6,10 +6,10 @@ num: 8
 Shows a window popup message.\
 Useful for extension creators to be able to easily notify the user of important events.\
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Message|	String|	The message you want to display. Can be multiline.
-|Freeze LB| Checkbox |Choose whether you want to temporarily freeze LioranBoard (i.e. pause all commands) while showing the popup.
+|Freeze LB| Checkbox |Choose whether you want to temporarily freeze SAMMI (i.e. pause all commands) while showing the popup.
 {:class='table table-primary'}
 
 

--- a/doc_posts/_commands-number/swap-red-blue.md
+++ b/doc_posts/_commands-number/swap-red-blue.md
@@ -3,9 +3,9 @@ title: "Swap Red & Blue"
 num: 6
 ---
 
-Swaps red and blue value for a color in HEX/DEC format and returns its DEC value. Useful for converting HTML colors to LioranBoard or OBS colors (as they use BGR instead of RGB).
+Swaps red and blue value for a color in HEX/DEC format and returns its DEC value. Useful for converting HTML colors to SAMMI or OBS colors (as they use BGR instead of RGB).
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 | Variable | String | Name of the variable containing the color value to swap red and blue. |
 {:class='table table-primary' }

--- a/doc_posts/_commands-object/object-get-first-key.md
+++ b/doc_posts/_commands-object/object-get-first-key.md
@@ -4,25 +4,10 @@ num: 4
 ---
 
 Retrieves the first object key. You can use this command together with [Object Get Next Key](#objectgetnextkey) to iterate over all object keys.\
-Unlike in some other languages, object keys are not sorted and their order is not guaranteed in LioranBoard.
-
-| Box Name | Type | Description | 
+Unlike in some other languages, object keys are not sorted and their order is not guaranteed.
+| Box Name | Type | Description |
 |-------|--------|--------|
 |Object|String|Name of the object you want to access
 |Save Variable|String|Variable name to save the retrieved key into
 {:class='table table-primary' }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/doc_posts/_commands-object/object-get-next-key.md
+++ b/doc_posts/_commands-object/object-get-next-key.md
@@ -4,16 +4,16 @@ num: 5
 ---
 
 Retrieves the next object key. You can use this command together with [Object Get First Key](#objectgetfirstkey) to iterate over all object keys.\
-Unlike in some other languages, object keys are not sorted and their order is not guaranteed in LioranBoard.
+Unlike in some other languages, object keys are not sorted and their order is not guaranteed.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------|
 |Object|String|Name of the object you want to access
 |Key|String|Object key to continue to iterate from
 |Save Variable|String|Variable name to save the retrieved key into
 {:class='table table-primary' }
 
-{% include media_modal.html img="get-next-key.png" w="100" btn="1" alt="Get a random object key and its value" pastebin="1Lir8tVC" %} 
+{% include media_modal.html img="get-next-key.png" w="100" btn="1" alt="Get a random object key and its value" pastebin="1Lir8tVC" %}
 
 
 

--- a/doc_posts/_commands-object/object-parse.md
+++ b/doc_posts/_commands-object/object-parse.md
@@ -3,13 +3,13 @@ title: "Parse Array/Object"
 num: 8
 ---
 
-Turns a JSON string into an array/object. Must be properly formatted (LioranBoard will give you a warning if it finds any formatting errors).\
+Turns a JSON string into an array/object. Must be properly formatted (SAMMI will give you a warning if it finds any formatting errors).\
 This way you can easily create a prepopulated object/array, as it supports nesting.\
 Read more about JSON syntax at [w3schools.com](https://www.w3schools.com/js/js_json_syntax.asp).
 
-{% include alert.html text="Parsing an array that's directly within another array is not supported." type="warning" %} 
+{% include alert.html text="Parsing an array that's directly within another array is not supported." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Array/Object Name	| String | Name of the variable to save the parsed array/object into
 |String Array/JSON	| JSON String | JSON string to parse

--- a/doc_posts/_commands-obs-general/fetch_obs.md
+++ b/doc_posts/_commands-obs-general/fetch_obs.md
@@ -4,19 +4,19 @@ num: 1
 ---
 Allows you to request data from OBS websocket and save it in a variable.
 
-This command should be followed by a `Wait until Variable Exists` command with an adequate timeout to allow the data to be sent to LioranBoard.
+This command should be followed by a `Wait until Variable Exists` command with an adequate timeout to allow the data to be sent to SAMMI.
 
 All the possible requests are documented in [OBS websocket protocol reference](https://github.com/Palakis/obs-websocket/blob/4.x-current/docs/generated/protocol.md).\
-The requested value will not be saved immediately, you must give you other commands a delay of 100-500ms to process the request.  
+The requested value will not be saved immediately, you must give you other commands a delay of 100-500ms to process the request.
 
 If the requested value is inside another object already, you can access it with a simple dot-notation.\
-For example, if you want to retrieve Brightness value from Color Correction Filter, you will notice that it is inside an object called settings. `{"settings": {"brightness": 0.78}, "status": "ok", "type": "color_filter"}</code>. In this case, the Fetch Value will be `settings.brightness`.  
+For example, if you want to retrieve Brightness value from Color Correction Filter, you will notice that it is inside an object called settings. `{"settings": {"brightness": 0.78}, "status": "ok", "type": "color_filter"}</code>. In this case, the Fetch Value will be `settings.brightness`.
 
 Use [JSON string validator](https://jsonlint.com/) if you want to make sure your formatting is correct.
 
-{% include alert.html text="If the name of the fetched value contains dots, it needs to be wrapped in parentheses like this: <code>(Filter.Transform.Rotation.X)</code>." type="warning" %} 
+{% include alert.html text="If the name of the fetched value contains dots, it needs to be wrapped in parentheses like this: <code>(Filter.Transform.Rotation.X)</code>." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |OBS|Dropdown|OBS to send this command to (if using multiple OBS)|
 |OBS command|	JSON String|	Works the same as the custom packet command. Do not include the `"message-id"` part.
@@ -38,7 +38,7 @@ Turn to real|	boolean|	Whether you expect a real value (=number) or a string.
 |<code class="user-select-all">"sceneItems":["sourceName":"Browser",...},{"sourceName":"Text GDI",...}]</code>|First source name in a specified scene|<code class="user-select-all">{"request-type":"GetSceneItemList","sceneName":"YOURSCENENAME"}</code>|sceneItems[0].sourceName|
 {:class='table table-secondary w-auto table-responsive table-hover text-break' }
 
-{% include example_public.html src="https://i.imgur.com/IH9L1VE.png" size="100" title="Add 1 to Text GDI+ Source" pastebin="ccUwx1GE" %}   
+{% include example_public.html src="https://i.imgur.com/IH9L1VE.png" size="100" title="Add 1 to Text GDI+ Source" pastebin="ccUwx1GE" %}
 
 
 

--- a/doc_posts/_commands-string/introduction.md
+++ b/doc_posts/_commands-string/introduction.md
@@ -9,7 +9,7 @@ Strings can contain numbers, however you must realize that `"5"` doesn’t have 
 You cannot add strings either, i.e. `"12" + "34"` isn’t `"46"`, it’s `"1234"`. `12 + 34` is `46`.\
 If you wish to convert a string to a number, you can use [String to Number]({{ "commands/number#stringtonumber" | relative_url }}) command.
 
-{% include alert.html text='In LioranBoard, use strings <b>without double</b> quotes in  <b>white</b> input boxes, and enclose them in  <b>double quotes</b> if the input box is  <b>yellow</b>.Otherwise LioranBoard will read them as real values and convert them to 0. ' type="warning" %} 
+{% include alert.html text='In SAMMI, use strings <b>without double</b> quotes in  <b>white</b> input boxes, and enclose them in  <b>double quotes</b> if the input box is  <b>yellow</b>.Otherwise SAMMI will read them as real values and convert them to 0. ' type="warning" %}
 
 
 

--- a/doc_posts/_commands-trigger/trigger-extension.md
+++ b/doc_posts/_commands-trigger/trigger-extension.md
@@ -3,10 +3,10 @@ title: "Trigger Extension Triggers"
 num: 3
 ---
 
-This is the same command Transmitter uses to send Extension triggers to LioranBoard.\
-Extremely useful as you can pass parameters from one button to another button (especially if it's an overlappable button with non persistent variables) and make it behave like a function in programming. 
+This is the same command Transmitter uses to send Extension triggers to SAMMI.\
+Extremely useful as you can pass parameters from one button to another button (especially if it's an overlappable button with non persistent variables) and make it behave like a function in programming.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------|
 |Extension Trigger|String|The name of the extension trigger to send
 |Trigger Data Object|Object|Same payload as sending data from the Transmitter. Populate the object with your desired parameters (simple values, arrays, other objects) you wish to be pulled in the receiving button.

--- a/doc_posts/_commands-trigger/trigger_pull.md
+++ b/doc_posts/_commands-trigger/trigger_pull.md
@@ -5,10 +5,10 @@ num: 1
 
 Used in combination with any triggers you set up for the button.\
 For example, if you set up a button with a Twitch Subs trigger, you can use this command to get the subscriber's name once the button is triggered.
- 
-Refer to our [Triggers]({{ "/triggers/twitch" | relative_url }}) section to learn more about triggers and their pull values. 
 
-| Box Name | Type | Description | 
+Refer to our [Triggers]({{ "/triggers/twitch" | relative_url }}) section to learn more about triggers and their pull values.
+
+| Box Name | Type | Description |
 |-------|--------|--------|
 |Variable | String | Variable name to save the pulled value into. |
 |Pull Value|Dropdown| Value you wish to pull from the trigger. Click on the hamburguer icon on the right to choose the correct value.
@@ -16,9 +16,9 @@ Refer to our [Triggers]({{ "/triggers/twitch" | relative_url }}) section to lear
 
 If you select **Trigger Type** in the dropdown menu, you can check what kind of event triggered the button (this replaces String: Get Trigger Type command from LB1). It will return a different numerical value for each type.
 
-There is also an array that lists all Trigger Types in the Global Variables section of the Variable Viewer in LioranBoard.
+There is also an array that lists all Trigger Types in the Global Variables section of the Variable Viewer in SAMMI.
 
-| Numerical Value | Trigger Type | 
+| Numerical Value | Trigger Type |
 |-------|--------|--------
 |0|Twitch Chat|
 |1|Twitch Subscriber|
@@ -30,7 +30,7 @@ There is also an array that lists all Trigger Types in the Global Variables sect
 |7|Hotkey|
 |8|Interval Trigger|
 |9|OBS Trigger|
-|10|LioranBoard Trigger|
+|10|SAMMI Trigger|
 |11|Twitch Moderation|
 |12|Extension Trigger|
 |13|Twitch Whispers|
@@ -47,17 +47,3 @@ There is also an array that lists all Trigger Types in the Global Variables sect
 |24|Trigger Button|
 |25|Trigger Button with Delay|
 {:class='table table-secondary w-auto table-hover text-break' }
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/doc_posts/_commands-twitch/chat-message.md
+++ b/doc_posts/_commands-twitch/chat-message.md
@@ -3,25 +3,25 @@ title: "Send Chat Message "
 num: 0
 ---
 
-Sends a message to your Twitch chat from your default account that is connected to LioranBoard.\
+Sends a message to your Twitch chat from your default account that is connected to SAMMI.\
 You can send emotes, whispers and chat commands (if your account has the privileges). See a list of **[all possible chat commands](https://help.twitch.tv/s/article/chat-commands?language=en_US#AllMods)**.\
 Whispers might not natively work. Make sure your linked Twitch account contains `Send Whispers` scope in your Twitch Connections-Edit Scope menu. Twitch may also flag you as a bot and ask you to **[verify your bot account](https://dev.twitch.tv/docs/irc/guide#:~:text=appear%20in%20chat.-,Requesting%20Verified%20Bot%20Status,expect%20a%20response%20via%20email.)**.
 
 
-{% include alert.html text="If you have linked more than one Twitch account to LioranBoard, you must specify the channel name, otherwise the message is sent to your Twitch account's channel that has <code>Join Channel</code> checked in your Twitch Connections menu" type="warning" %} 
+{% include alert.html text="If you have linked more than one Twitch account to SAMMI, you must specify the channel name, otherwise the message is sent to your Twitch account's channel that has <code>Join Channel</code> checked in your Twitch Connections menu" type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Message|String | The message to be sent over the chat.|
 |Channel Name |	String	| Channel to send the message to. Leave blank unless you have multiple accounts connected to LB (all lowercase).
 {:class='table table-primary'}
 
-| Chat Message Example | Description |  
+| Chat Message Example | Description |
 |-------|--------|--------
 |/followers|Sets the chat to follower mode|
 |/emoteonly|Sets chat to emote only mode
 |/clear|Clears the chat|
-|/w lioran|Sends a whisper to Lioran|
+|/w commanderroot|Sends a whisper to commanderroot|
 |/ban lioran| Bans Lioran|
 {:class='table table-secondary w-auto table-hover data-toggle='table' text-break }
 

--- a/doc_posts/_commands-twitch/create-reward.md
+++ b/doc_posts/_commands-twitch/create-reward.md
@@ -3,9 +3,9 @@ title: "Create Reward"
 num: 13.1
 ---
 
-Creates a Channel Point Reward on Twitch that will be owned by LioranBoard. Make sure you use a 'Wait until Timeout' command after this command, before adding any other commands after it.
+Creates a Channel Point Reward on Twitch that will be owned by SAMMI. Make sure you use a 'Wait until Timeout' command after this command, before adding any other commands after it.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Login Name|String|Your Twitch login name (all lowercase characters)
 |Title|String|What you want to name your new reward.

--- a/doc_posts/_commands-twitch/delete-reward.md
+++ b/doc_posts/_commands-twitch/delete-reward.md
@@ -4,9 +4,9 @@ num: 13.8
 ---
 
 Deletes your previously created reward.\
-You can only delete rewards that were previously created with LioranBoard. This means the reward must show that it is 'Owned' by LioranBoard in the Twitch Connections > Edit Channel Points window.
+You can only delete rewards that were previously created with SAMMI. This means the reward must show that it is 'Owned' by SAMMI in the Twitch Connections > Edit Channel Points window.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Login Name|String|Your Twitch login name (all lowercase characters)
 |Reward ID|Dropdown|ID of the custom reward to delete.

--- a/doc_posts/_commands-twitch/edit-reward.md
+++ b/doc_posts/_commands-twitch/edit-reward.md
@@ -3,11 +3,11 @@ title: "Edit Reward"
 num: 13.5
 ---
 
-Updates a Custom Reward created on your channel. This means that the reward must show that it is 'Owned' by LioranBoard in the Twitch Connections > Edit Channel Points window.
+Updates a Custom Reward created on your channel. This means that the reward must show that it is 'Owned' by SAMMI in the Twitch Connections > Edit Channel Points window.
 
-Selecting 'Dupe' in the Edit Channel Points window allows you to duplicate your existing Twitch-created Channel Point Rewards so that they are created and owned by LioranBoard. Once you have duplicated the rewards you want, go back into Twitch and delete your Twitch-created rewards.
+Selecting 'Dupe' in the Edit Channel Points window allows you to duplicate your existing Twitch-created Channel Point Rewards so that they are created and owned by SAMMI. Once you have duplicated the rewards you want, go back into Twitch and delete your Twitch-created rewards.
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Login Name|String|Your Twitch login name (all lowercase characters)
 |Reward ID|Dropdown|ID of the custom reward to update. You can select it from the dropdown menu or type manually.

--- a/doc_posts/_commands-twitch/get-latest-poll-pr.md
+++ b/doc_posts/_commands-twitch/get-latest-poll-pr.md
@@ -3,10 +3,10 @@ title: "Get Latest Poll/Prediction ID"
 num: 16.5
 ---
 
-Gets the latest poll or prediction ID to use with [Get Poll/Prediction Result]({{ "#getpollpredictionresult" | strip }}). This only works for predictions/polls initiated through LioranBoard.
+Gets the latest poll or prediction ID to use with [Get Poll/Prediction Result]({{ "#getpollpredictionresult" | strip }}). This only works for predictions/polls initiated through SAMMI.
 
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Login Name|String|Your Twitch login name (all lowercase characters)
 |Get|Dropdown |Whether it's a poll or prediction ID

--- a/doc_posts/_commands-twitch/get-user-info.md
+++ b/doc_posts/_commands-twitch/get-user-info.md
@@ -5,15 +5,15 @@ num: 6
 
 Retrieves information about a Twitch user. Provide either their username or user ID (leave the other one empty).
 
-If your LioranBoard receiver crashes with an error log relating to this command, make sure you have enabled the `View email address` scope in your Twitch connection settings. The command will not work without this scope enabled. 
+If your receiver crashes with an error log relating to this command, make sure you have enabled the `View email address` scope in your Twitch connection settings. The command will not work without this scope enabled.
 
-{% include alert.html text="This command needs some time to execute, either delay your next commands by 1-2 seconds or use <a href='/docs2/commands/wait#waituntilvariableexists'>Wait Until Variable Exists</a> command." type="warning" %} 
+{% include alert.html text="This command needs some time to execute, either delay your next commands by 1-2 seconds or use <a href='/docs2/commands/wait#waituntilvariableexists'>Wait Until Variable Exists</a> command." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |User Name|String|Username to get the information for
 |User ID|Number|User ID to get the information for
-|Save Variable|String|Variable to save the whole object 
+|Save Variable|String|Variable to save the whole object
 {:class='table table-primary'}
 
 You can access the response object fields by using [Get Object Variable]({{ "commands/object#getobjectvariable" | relative_url }}) command. The object is the Save Variable and key is one of the response fields.
@@ -21,7 +21,7 @@ You can access the response object fields by using [Get Object Variable]({{ "com
 
 **Response fields:**
 
-| Field | Type| Description| 
+| Field | Type| Description|
 |-------|--------|--------
 |broadcaster_type|	string|	User’s broadcaster type: "partner", "affiliate", or "".
 |description|	string|	User’s channel description.
@@ -36,7 +36,7 @@ You can access the response object fields by using [Get Object Variable]({{ "com
 |created_at|	string|	Date when the user was created.
 {:class='table table-secondary w-auto table-hover' }
 
-{% include example_public.html src="https://i.imgur.com/1wykfcB.png" size="100" title="Get a follower's profile picture" pastebin="FcaArEdc" %}  
+{% include example_public.html src="https://i.imgur.com/1wykfcB.png" size="100" title="Get a follower's profile picture" pastebin="FcaArEdc" %}
 
 
 

--- a/doc_posts/_commands-twitch/join-channel.md
+++ b/doc_posts/_commands-twitch/join-channel.md
@@ -4,11 +4,11 @@ num: 2
 ---
 
 This command lets you join any Twitch chat channel.\
-You do not need to use this command to join your own channel as long as it's linked to your LioranBoard, as it will join the chat automatically as soon as you launch Transmitter.
+You do not need to use this command to join your own channel as long as it's linked to SAMMI, as it will join the chat automatically as soon as you launch Transmitter.
 
-{% include alert.html text="Use this command to join any alternate accounts you have linked to LioranBoard and wish to listen to the chat traffic on." type="info" %} 
+{% include alert.html text="Use this command to join any alternate accounts you have linked to SAMMI and wish to listen to the chat traffic on." type="info" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Channel Name |	String | Twitch channel name. Must be the login name, not display name.
 {:class='table table-primary'}

--- a/doc_posts/_commands-variable/introduction.md
+++ b/doc_posts/_commands-variable/introduction.md
@@ -4,9 +4,9 @@ num: 0
 ---
 
 Variables are containers for storing data values (including numbers and strings), that can be reused over and over again.\
-Variable names are case sensitive, meaning that "Variable" and "variable" are not going to have the same value. Variable name must always start with a letter and must only contain letters, numbers and `_`. 
+Variable names are case sensitive, meaning that "Variable" and "variable" are not going to have the same value. Variable name must always start with a letter and must only contain letters, numbers and `_`.
 
-{% include alert.html text="You can view all existing variables by pressing Variable Viewer at the bottom menu of your LioranBoard" type="info" %}
+{% include alert.html text="You can view all existing variables by pressing Variable Viewer at the bottom menu of SAMMI" type="info" %}
 
 #### Global Variables
 All global variables are stored inside `global` variables object and are accessible from any button at all times. Some of these variables are permanent.\
@@ -30,15 +30,15 @@ If you uncheck the box, the variables will be accessible only when the button is
 If you right click on a button, you can edit its INIT variables.\
 These exist to prevent crashes if you have enabled persistent variables.\
 The window uses a simple JSON format to initialize your variables.\
-For example, if you want your variable `name` to have a value of `LioranBoard` and your variable `age` to have a value of 18 on initilization, you can do:
+For example, if you want your variable `name` to have a value of `SAMMI` and your variable `age` to have a value of 18 on initilization, you can do:
 ```
 {
-	"name": "LioranBoard",
+	"name": "SAMMI",
 	"age": 18,
 }
 ```
 
-{% include alert.html text='Strings must be enclosed in <code>"</code>, but numbers (real values) must be without <code>"</code> (else they will be also regarded as strings).' type='warning' %} 
+{% include alert.html text='Strings must be enclosed in <code>"</code>, but numbers (real values) must be without <code>"</code> (else they will be also regarded as strings).' type='warning' %}
 
 You can also initiliaze complex variables, such as arrays or objects:
 ```
@@ -56,7 +56,7 @@ You can also initiliaze complex variables, such as arrays or objects:
 
 #### Variable types
 
-| Variable Type | Example | Color in variable window | 
+| Variable Type | Example | Color in variable window |
 |-------|--------|--------|
 |Real value (number) | `50` | green|
 |String (text) | `"My Cat"` or `'My Cat'` | blue|
@@ -67,37 +67,37 @@ You can also initiliaze complex variables, such as arrays or objects:
 |Null | Variable with empty or non existent reference | red|
 {:class='table table-secondary w-auto table-responsive table-hover'}
 
-**Real value (number)**  
+**Real value (number)**
 
 Variable containing numbers only. Negative values, decimal points and Euler's numbers are allowed.\
 Examples: `50`, `1.25`, `-15`, `10e+2`
 
-**String (text)**  
+**String (text)**
 
 Variable that contains not just numbers, but also other characters (possibly mixed with numbers).\
 If you are inserting a string into a YELLOW variable box, you must wrap it in double or single quotes.\
 Note that a string containing only numbers is not regarded as a number and cannot be used as such. You must use 'String to Number' command to convert to number first.\
 Examples: `"Hello world!"`, `'This is cool'`, `"The tickets cost $50"`, `'50'` (still regarded as a string!)
 
-**Boolean**  
+**Boolean**
 
-In LioranBoard, boolean is a number that is either 0 (false) or 1 (true).\
-{% include alert.html text="In some languages comparing <code>2</code> or non empty string returns true, however in LioranBoard it will always return false. The only value that returns true is <code>1</code>. " type="warning" %} 
+In SAMMI, boolean is a number that is either 0 (false) or 1 (true).\
+{% include alert.html text="In some languages comparing <code>2</code> or non empty string returns true, however in SAMMI it will always return false. The only value that returns true is <code>1</code>. " type="warning" %}
 
-**Array**  
+**Array**
 
 Array is a special variable which can hold more than one value at a time. Learn more about arrays in our [Array Introduction section]({{ "commands/array#introduction" | relative_url }}).
 
-**Object**  
+**Object**
 
 Object is another special variables which can hold more than one value at a time. Unlike arrays, objects have named values, key-value pairs. Learn more about objects in our [Object Introduction section]({{ "commands/object#introduction" | relative_url }}).
 
 #### White vs. Yellow Box for parameters
-When you start using commands in LioranBoard, you will notice that some parameter boxes have yellow color and some have white color.
+When you start using commands in SAMMI, you will notice that some parameter boxes have yellow color and some have white color.
 {% include image.html w="100" src="variable_box.png" alt="Different parameter box colors" %}
 It's extremely important to know the difference as you need to **format your input according to the color of the box**.
 
-| Operation | White Box| Yellow Box| 
+| Operation | White Box| Yellow Box|
 |-------|--------|--------
 |Inserting another variable | You must wrap other variables in */$$/*. <br/> `/$myVariable$/` | You can directly type another variable.<br/> `myVariable`
 |Inserting array value | You must wrap them in */$$/*. <br/> `/$myArray[0]$/` | You can directly insert them. <br/> `myArray[0]`

--- a/doc_posts/_commands-variable/set-boolean.md
+++ b/doc_posts/_commands-variable/set-boolean.md
@@ -5,11 +5,11 @@ num: 3.5
 ---
 
 Allows you to set a boolean variable.\
-In LioranBoard, boolean is a number that is either 0 (false) or 1 (true).
+In SAMMI, boolean is a number that is either 0 (false) or 1 (true).
 
-{% include alert.html text="In some languages comparing 2 or non empty string returns true, however in LioranBoard it will always return false. The only value that returns true is 1." type="warning" %} 
+{% include alert.html text="In some languages comparing 2 or non empty string returns true, however in SAMMI it will always return false. The only value that returns true is 1." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 | Variable Name | String | Name of the variable to save the boolean value. |
 |Boolean|Boolean {% include asterisk.html%}|Boolean value you want to set the variable to. Will be converted to true or false.

--- a/doc_posts/_commands-variable/set-button-variable.md
+++ b/doc_posts/_commands-variable/set-button-variable.md
@@ -4,12 +4,12 @@ title: "Set Button Variable"
 num: 2
 ---
 
-Creates a new button variable or modifies an existing one.\ 
-Button variables are other buttons local variables. You cannot set a button variable for a button that has persistent variables disabled, this will crash LioranBoard.
+Creates a new button variable or modifies an existing one.\
+Button variables are other buttons local variables. You cannot set a button variable for a button that has persistent variables disabled, this will crash SAMMI.
 
-{% include alert.html text="Variable names can contain numbers, letters and _, but cannot start with a number itself. " type="warning" %} 
+{% include alert.html text="Variable names can contain numbers, letters and _, but cannot start with a number itself. " type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |Button ID | String | The button you want to set the variable for.
 | Variable Name | String | Name of the variable. |

--- a/doc_posts/_commands-variable/set-local-variable.md
+++ b/doc_posts/_commands-variable/set-local-variable.md
@@ -7,9 +7,9 @@ num: 1
 Creates a new local variable or modifies an existing one.\
 Local variables are contained in the button that created them. They can be accessed from other buttons by using Set/Get Button Variable (as long as the button has persistent variables enabled).
 
-{% include alert.html text="Variable names can contain numbers, letters and _, but cannot start with a number itself. " type="warning" %} 
+{% include alert.html text="Variable names can contain numbers, letters and _, but cannot start with a number itself. " type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 | Variable Name | String | Name of the variable. |
 | Operation | Dropdown | Operator you wish to use on the value.|
@@ -17,7 +17,7 @@ Local variables are contained in the button that created them. They can be acces
 {:class='table table-primary'}
 
 **Advanced Users**\
-You can use this command to create and modify all variables, including global and button variables, object keys and array items. Lots of commands in LioranBoard are redundant and rather targeted at users with no coding knowledge.\
+You can use this command to create and modify all variables, including global and button variables, object keys and array items. Lots of commands in SAMMI are redundant and rather targeted at users with no coding knowledge.\
 Global variables: Use `global.` prefix, since they're all stored in an object called `global`.\
 Button variables: Use `buttonID.` prefix, since they're all stored in an object named after the button ID.\
 Array Values: Use `myArray[index]` to change a value inside an array.\

--- a/doc_posts/_commands-wait/wait-until-is.md
+++ b/doc_posts/_commands-wait/wait-until-is.md
@@ -6,9 +6,9 @@ num: 9
 Pauses all the button commands from executing until the variable contains a specific value.\
 Similar to async/await in JavaScript. Very useful command to use together with *Http Request command*.
 
-{% include alert.html text="You cannot use this command for non existing variables as it will crash LioranBoard. You can use button Init Variables to ensure the variable always exists." type="warning" %} 
+{% include alert.html text="You cannot use this command for non existing variables as it will crash SAMMI. You can use button Init Variables to ensure the variable always exists." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------|
 | Variable | String | Variable name to wait for |
 | Compare | Dropdown | Compare operator you wish to compare the variable to the value.|

--- a/doc_posts/_faq-commands/complex-math.md
+++ b/doc_posts/_faq-commands/complex-math.md
@@ -3,10 +3,10 @@ title: Complex Math
 num: 11
 ---
 
-You can execute complex math operations in every parameter box, using a mix of variables and real values.  
-Note that there's a significant difference between [White and Yellow box]({{ "commands/introduction#inputboxes" | relative_url }}).  
+You can execute complex math operations in every parameter box, using a mix of variables and real values.
+Note that there's a significant difference between [White and Yellow box]({{ "commands/introduction#inputboxes" | relative_url }}).
 
-Each time you want LioranBoard to execute any kind of math, you need to wrap the whole sequence in parentheses: `(some math operation)`, for example `(variable+3*5+round(variable2))` or `(variable+10)` (applies for yellow boxes, as you must use `/$$/` in white boxes).  
+Each time you want SAMMI to execute any kind of math, you need to wrap the whole sequence in parentheses: `(some math operation)`, for example `(variable+3*5+round(variable2))` or `(variable+10)` (applies for yellow boxes, as you must use `/$$/` in white boxes).
 
 The following examples show the usage in **yellow boxes**.
 
@@ -27,4 +27,3 @@ The following examples show the usage in **yellow boxes**.
 |div|	Divide (no decimals). Space required before and after div.|	`7 div 3` = 2 or `(7+3) div (2+4)` = 1
 {:class='table table-primary table-hover' }
 
- 

--- a/doc_posts/_faq-commands/custom-fonts.md
+++ b/doc_posts/_faq-commands/custom-fonts.md
@@ -4,5 +4,5 @@ title: Custom fonts and special characters
 num: 13
 ---
 
-Any characters not supported by LioranBoard will be displayed as invisible characters within LioranBoard.\
-The characters themselves are correctly saved and will be correctly displayed outside of LioranBoard (such as in your Twitch Send message). 
+Any characters not supported by SAMMI will be displayed as invisible characters within SAMMI.\
+The characters themselves are correctly saved and will be correctly displayed outside of SAMMI (such as in your Twitch Send message).

--- a/doc_posts/_faq-commands/see-variables.md
+++ b/doc_posts/_faq-commands/see-variables.md
@@ -4,5 +4,5 @@ title: How to see all variables
 num: 7
 ---
 
-Press `Variable Viewer` in your LioranBoard. You can see all global and persistent button IDs and click on the individual ones to see their variables.\
+Press `Variable Viewer` in SAMMI. You can see all global and persistent button IDs and click on the individual ones to see their variables.\
 Learn more about all variable types in our [Commands-Variables]({{ "commands/variables#introduction" | relative_url }}) section.

--- a/doc_posts/_faq-commands/share-deck.md
+++ b/doc_posts/_faq-commands/share-deck.md
@@ -3,5 +3,5 @@ title: Share a deck
 num: 2
 ---
 
-In LioranBoard, select a deck you wish to share with someone, right click on it and select **Copy Deck**. This will copy all your JSON deck data into your clipboard. You can then paste it into a text file to share with others.\
-To Import a deck, press **Paste Deck** in LioranBoard's side menu. 
+In SAMMI, select a deck you wish to share with someone, right click on it and select **Copy Deck**. This will copy all your JSON deck data into your clipboard. You can then paste it into a text file to share with others.\
+To Import a deck, press **Paste Deck** in SAMMI's side menu.

--- a/doc_posts/_faq-commands/shortcuts-button.md
+++ b/doc_posts/_faq-commands/shortcuts-button.md
@@ -4,7 +4,7 @@ title: Trigger a button with keyboard press
 num: 3
 ---
 
-You can set up a hotkey to trigger a LioranBoard button by right clicking on the button in your deck - **Edit Triggers**. Press **+**, select **Hotkey** and fill out the **Key** field and optionally check whatever modifiers you want to use (for example Ctrl + K). Don't forget to hit save!
+You can set up a hotkey to trigger a SAMMI button by right clicking on the button in your deck - **Edit Triggers**. Press **+**, select **Hotkey** and fill out the **Key** field and optionally check whatever modifiers you want to use (for example Ctrl + K). Don't forget to hit save!
 
 {% include image.html w="100" src="hotkey-trigger.png" alt="Hotkey trigger for a button" %}
 

--- a/doc_posts/_faq-general/elgato.md
+++ b/doc_posts/_faq-general/elgato.md
@@ -3,5 +3,5 @@ title: Elgato Stream Deck
 num: 4
 ---
 
-LioranBoard can natively communicate with Elgato Stream Deck via key presses.\
-If you're looking for even better functionality, there is an extension [LioranBoard Bridge for Elgato Stream Deck](https://streamup.tips/product/lioranboard-bridge-elgato) from StreamUp that you might wanna check out!
+SAMMI can natively communicate with Elgato Stream Deck via key presses.\
+If you're looking for even better functionality, there is an extension [SAMMI Bridge for Elgato Stream Deck](https://streamup.tips/product/lioranboard-bridge-elgato) from StreamUp that you might wanna check out!

--- a/doc_posts/_faq-general/how-to-do-x.md
+++ b/doc_posts/_faq-general/how-to-do-x.md
@@ -3,9 +3,8 @@ title: How do I do X?
 num: 1
 ---
 
-Making your own buttons in LioranBoard is a little bit like programming. It takes some time to learn how everything works.\
+Making your own buttons in SAMMI is a little bit like programming. It takes some time to learn how everything works.\
 You can start with something as small as making a button to change your OBS scene and slowly work towards more complex buttons.
 This documentation should help you achieve that!
 
 *We welcome new members on our Discord server to ask questions if they encounter a problem with their buttons or commands, but discourage asking for a whole custom button to be created just for their needs. In that case you're free to request a commission instead.*
- 

--- a/doc_posts/_faq-general/other-apps.md
+++ b/doc_posts/_faq-general/other-apps.md
@@ -3,7 +3,7 @@ title: Connecting to other apps
 num: 7
 ---
 
-Lioranboard can connect to any app or service that has public API or websocket access.\
+SAMMI can connect to any app or service that has public API or websocket access.\
 It is done via custom made extensions.
 All available and approved extensions are listed in the #Releases channel in our [Discord server](https://discord.gg/dXez8Zh).\
 If none of them suits your needs, feel free ask in the #Suggestions channel or request a commission!

--- a/doc_posts/_faq-general/remote-connection.md
+++ b/doc_posts/_faq-general/remote-connection.md
@@ -3,7 +3,7 @@ title: Remote Connection
 num: 3
 ---
 
-It's possible to remotely connect and control your LioranBoard via Stream Deck from anywhere in the world.\
+It's possible to remotely connect and control SAMMI via Stream Deck from anywhere in the world.\
 There are multiple ways to accomplish this. This documentation covers the easiest and most accessible one.
 
 1. Download Ngrok and sign up for an account.
@@ -11,11 +11,11 @@ There are multiple ways to accomplish this. This documentation covers the easies
 3. Go to the downloaded file, unzip it and run ngrok.exe. You should see a command line open.
 4. Type `ngrok authtoken YOURAUTHTOKEN` and press enter. You should see a message `Authtoken saved to configuration file: C:\Users\...`. This step is necessary to prevent your session from timing out.
 5. To start the tunnel, type `ngrok tcp 9423` and hit enter. <br/> The default region is US. You can change it by adding `-region=REGION` flag. Available regions: us, eu, ap, au, sa, jp, in. Example: `ngrok tcp -region=eu 9423`.
-6. You should see your session started. Go to your Stream Deck and paste the new IP and port from the Forwarding line (make sure to omit the `tcp://` part). As long as your tunnel is active, you can connect to your Receiver from anywhere in the world now! :)  
+6. You should see your session started. Go to your Stream Deck and paste the new IP and port from the Forwarding line (make sure to omit the `tcp://` part). As long as your tunnel is active, you can connect to your Receiver from anywhere in the world now! :)
    {% include image.html w="50" src="ngrok.png" alt="Creating a new tunnel via ngrok" %}
 
 All currently active tunnels can be seen on your dashboard.\
 If you wish to close the tunnel, you can press CTRL+C or type `taskkill /f /im ngrok.exe` in the command line and press enter.
 
-{% include alert.html text="Do not share your tunnel IP and port with anyone else. If you accidentally leak it, you should terminate the service and relaunch it, as anyone who knows the address could potentially connect and press buttons in your Stream Deck." type="warning" %} 
+{% include alert.html text="Do not share your tunnel IP and port with anyone else. If you accidentally leak it, you should terminate the service and relaunch it, as anyone who knows the address could potentially connect and press buttons in your Stream Deck." type="warning" %}
 

--- a/doc_posts/_faq-general/translations.md
+++ b/doc_posts/_faq-general/translations.md
@@ -3,5 +3,5 @@ title: Translations
 num: 8
 ---
 
-LioranBoard will most likely not be translated to other languages in the near future.\
+SAMMI will most likely not be translated to other languages in the near future.\
 If you'd like to contribute to translating this documentation to other languages,  <a href='&#109;a&#105;lto&#58;lior&#97;%6Eboa&#37;7&#50;d&#37;40g&#109;&#97;il&#37;2E%63o&#109;'>please let us know!</a>

--- a/doc_posts/_integrations-twitch/twitch.md
+++ b/doc_posts/_integrations-twitch/twitch.md
@@ -7,67 +7,67 @@ permalink: /integrations/twitch
 type: fullpage
 ---
 
-LioranBoard can connect to your Twitch account, remotely control it and listen to events in your stream. 
+SAMMI can connect to your Twitch account, remotely control it and listen to events in your stream.
 
 {% include alert.html text="Your Transmitter must be running at all times for Twitch to stay connected." type="warning" %}
 
 #### Link a single Twitch account
-We need to authorize LioranBoard to interact with your Twitch account.
+We need to authorize SAMMI to interact with your Twitch account.
 
-1. In your LioranBoard click on **Twitch Connections** button.
-2. Click on **Open URL** which should open a new browser window and redirect you to Twitch to authorize LioranBoard.  
-3. Press **Authorize** and wait to be redirected again to see `All good, you can go back to LioranBoard now` message in your browser.
-4. Back in LioranBoard you should now see your Twitch account in the list!  
+1. In SAMMI click on **Twitch Connections** button.
+2. Click on **Open URL** which should open a new browser window and redirect you to Twitch to authorize SAMMI.
+3. Press **Authorize** and wait to be redirected again to see `All good, you can go back to SAMMI now` message in your browser.
+4. Back in SAMMI you should now see your Twitch account in the list!
 
 
    {% include video.html w="75" src="link-twitch.mp4" alt="Linking a Twitch account" %}
 
-{% include alert.html text="You must relink your Twitch account every 60 days as that's when your token expires. LioranBoard will automatically remind you to do so." type="warning" %} 
+{% include alert.html text="You must relink your Twitch account every 60 days as that's when your token expires. SAMMI will automatically remind you to do so." type="warning" %}
 
 **Linked Twitch account's settings:**
 
 {% include image.html w="75" src="account-settings.png" alt="Active Twitch Connection" %}
 
-- `Join chat under this name` - all your Twitch chat messages and whispers from LioranBoard will be sent under this Twitch account's name
+- `Join chat under this name` - all your Twitch chat messages and whispers from SAMMI will be sent under this Twitch account's name
 - `Join channel` - whether you want to join this Twitch account's chat and listen for chat messages
 - `Listen for` - check all events you wish to listen for and received triggers for. Some events will be greyed out if you're not affiliate.
-- `Revoke Token` - disconnect your Twitch account from LioranBoard
-- (only if affiliate) `Edit Channel Points` - allows you to create, modify and delete all your current channel points.
+- `Revoke Token` - disconnect your Twitch account from SAMMI
+- (only if affiliate) `Edit Channel Points` - allows you to create, modify and delete all your current channel points
 
 **Twitch Connections General Settings**
 
 {% include image.html w="75" src="account-settings2.png" alt="Active Twitch Connection" %}
 
 - `Connect/Disconnect Twitch Chat` - connect to Twitch chat to be able to receive and send chat messages
-- `Auto connect to Twitch Chat` - check this if you want LioranBoard to automatically connect to Twitch chat once launched, otherwise you will have to press Connect Twitch Chat button every time.
+- `Auto connect to Twitch Chat` - check this if you want SAMMI to automatically connect to Twitch chat once launched, otherwise you will have to press Connect Twitch Chat button every time.
 - `Copy URL` - if you would rather copy the URL instead of opening it in your default browser to link your account, you can use this option instead
-- `Edit Scopes` - allows you to edit scopes, i.e. what information LioranBoard can access on your Twitch account. For example, if you want to be able to listen to poll events, you must check View & Edit Polls scope. **If you edit any scopes, you must relink your account (revoke token and link it again) for it to take effect.**
+- `Edit Scopes` - allows you to edit scopes, i.e. what information SAMMI can access on your Twitch account. For example, if you want to be able to listen to poll events, you must check View & Edit Polls scope. **If you edit any scopes, you must relink your account (revoke token and link it again) for it to take effect.**
 - `Done` - click Done to save the settings
 
 
 #### Link multiple Twitch accounts
-You can link multiple Twitch accounts to your LioranBoard by following the same steps in [Link a single Twitch account](#linkasingletwitchaccount) section.\
-This is useful if you want to use a different Twitch account to send Twitch chat messages from. It makes it easier for your viewers to tell the difference between you personally interacting with them and any automated messages you have set up in LioranBoard.
+You can link multiple Twitch accounts to SAMMI by following the same steps in [Link a single Twitch account](#linkasingletwitchaccount) section.\
+This is useful if you want to use a different Twitch account to send Twitch chat messages from. It makes it easier for your viewers to tell the difference between you personally interacting with them and any automated messages you have set up in SAMMI.
 
-{% include alert.html text="All Twitch chat messages will be sent from your Twitch account that is marked as <strong>Join chat under this name</strong> in the <code>Twitch Connections</code> menu. You can freely switch to a different account your messages will be sent from." type="danger" %} 
+{% include alert.html text="All Twitch chat messages will be sent from your Twitch account that is marked as <strong>Join chat under this name</strong> in the <code>Twitch Connections</code> menu. You can freely switch to a different account your messages will be sent from." type="danger" %}
 
 **Listen to Twitch events from your alternate account(s)**\
-LioranBoard will automatically listen to all selected events and chat (if Join Channel is checked) from all your Twitch accounts.
+SAMMI will automatically listen to all selected events and chat (if Join Channel is checked) from all your Twitch accounts.
 
-{% include alert.html text="LioranBoard doesn't have a way to tell where your Twitch triggers come from, be it your main or one of your alternate accounts." type="warning" %} 
+{% include alert.html text="SAMMI doesn't have a way to tell where your Twitch triggers come from, be it your main or one of your alternate accounts." type="warning" %}
 
 **Remember to specify channel name when using Twitch: Chat message command**\
-If you've linked more than more Twitch account to your LioranBoard, you must specify the channel name in your [Twitch: Send Message]({{ "commands/twitch#sendchatmessage" | relative_url }}) command. Otherwise the message will be sent to your primary LioranBoard account's channel (the one with `Join chat under this name` selected). NOTE: The channel name must be in all lowercase. Otherwise the message will not appear in chat until user refreshes their chat.
+If you've linked more than more Twitch account to SAMMI, you must specify the channel name in your [Twitch: Send Message]({{ "commands/twitch#sendchatmessage" | relative_url }}) command. Otherwise the message will be sent to your primary SAMMI account's channel (the one with `Join chat under this name` selected). NOTE: The channel name must be in all lowercase. Otherwise the message will not appear in chat until user refreshes their chat.
 
 #### Listen to Twitch Events
 
-Once you link your account(s), LioranBoard automatically connects to Twitch PubSub and Twitch Chat IRC (if you pressed Connect Twitch Chat button) to listen to all selected Twitch events and Twitch chat.\
+Once you link your account(s), SAMMI automatically connects to Twitch PubSub and Twitch Chat IRC (if you pressed Connect Twitch Chat button) to listen to all selected Twitch events and Twitch chat.\
 Learn more about all Twitch event triggers in our [Triggers-Twitch]({{ "triggers/twitch" | relative_url }}) section.
 
 
 #### Send Twitch chat messages
 
-LioranBoard can natively send Twitch chat messages, whispers and moderation commands (if the linked account has the permissions) to any Twitch chat channel by using [Twitch: Send Message]({{ "commands/twitch#sendchatmessage" | relative_url }}) command.
+SAMMI can natively send Twitch chat messages, whispers and moderation commands (if the linked account has the permissions) to any Twitch chat channel by using [Twitch: Send Message]({{ "commands/twitch#sendchatmessage" | relative_url }}) command.
 
 See a list of all possible [Twitch chat mod commands](https://help.twitch.tv/s/article/chat-commands?language=en_US#AllMods).
 

--- a/doc_posts/_triggers/general.md
+++ b/doc_posts/_triggers/general.md
@@ -7,14 +7,14 @@ type: fullpage
 permalink: /triggers/general
 ---
 
-LioranBoard has some very useful internal triggers.\
-For example, you can make your buttons automatically trigger every time you start LioranBoard, when you press a specific hotkey or put them on a timer.
+SAMMI has some very useful internal triggers.\
+For example, you can make your buttons automatically trigger every time you start SAMMI, when you press a specific hotkey or put them on a timer.
 
-#### Add a new trigger 
+#### Add a new trigger
 You can attach a trigger by right clicking on a button - Add/Edit Twitch Triggers, clicking on the + sign and selecting one of the General Triggers.
-In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the event.   
+In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the event.
 
-#### Trigger types  
+#### Trigger types
 
 
 ##### Hotkey
@@ -22,7 +22,7 @@ In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpul
 Trigger a button when you press a specified hotkey.\
 You can select a key and attach a modifier (or multiple modifier).
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Key | Dropdown | Key press to listen to
 | Ctrl (optional) | Checkbox | Whether you want to attach Ctrl modifier, for example press CTRL+K.
@@ -30,16 +30,16 @@ You can select a key and attach a modifier (or multiple modifier).
 | Shift (optional) | Checkbox | Whether you want to attach Shift modifier, i.e. press Shift+K.
 {:class='table table-primary' }
 
-{% include alert.html text="Trigger Pull Data command doesn't let you check which key press triggered the button" type="warning" %} 
+{% include alert.html text="Trigger Pull Data command doesn't let you check which key press triggered the button" type="warning" %}
 
 <hr>
 
 ##### Repeat Interval
 Repeat interval allows you to continously trigger a button on a timer.\
-**Repeat interval is started as soon as LioranBoard starts up (or resets) and cannot be freely enabled or disabled with a command.**\
+**Repeat interval is started as soon as SAMMI starts up (or resets) and cannot be freely enabled or disabled with a command.**\
 You can use **[Block Button/Group]({{ "commands/button#blockbuttongroup" | relative_url }})** command to block a button on a timer from executing.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Milliseconds | Int | How often to trigger the button.
 {:class='table table-primary' }
@@ -48,26 +48,26 @@ You can use **[Block Button/Group]({{ "commands/button#blockbuttongroup" | relat
 <hr>
 
 
-##### LioranBoard Trigger
-These triggers allows you to listen to LioranBoard state and connection changes.
+##### SAMMI Trigger
+These triggers allows you to listen to SAMMI state and connection changes.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Type | Dropdown | Select type of the trigger.
 {:class='table table-primary' }
 
-| Trigger Name | Event | 
+| Trigger Name | Event |
 |-------|--------|
-|LioranBoard Startup| Lioranboard starts up. 
-|LioranBoard Shutdown | Before LioranBoard shut downs. Does not work if LioranBoard crashes.
-|LioranBoard Deck Reload| Decks are reloaded (when you press Save button)
-|LioranBoard Reset | You use the reset button.
-|OBS Connected | Every time LioranBoard connects to OBS.
-|OBS Disconnected|Every time LioranBoard disconnects from OBS.
-|Twitch Connected | Every time LioranBoard connects to Twitch.
-|Twitch Disconnected |Every time LioranBoard disconnects from Twitch.
-|Streamdeck/Transmitter Connected| Every time Stream Deck or Transmitter connects to LioranBoard.
-|Streamdeck/Transmitter Disconnected| Every time Stream Deck or Transmitter disconnects from LioranBoard.
+|SAMMI Startup| SAMMI starts up.
+|SAMMI Shutdown | Before SAMMI shut down. Does not work if SAMMI crashes.
+|SAMMI Deck Reload| Decks are reloaded (when you press Save button)
+|SAMMI Reset | You use the reset button.
+|OBS Connected | Every time SAMMI connects to OBS.
+|OBS Disconnected|Every time SAMMI disconnects from OBS.
+|Twitch Connected | Every time SAMMI connects to Twitch.
+|Twitch Disconnected |Every time SAMMI disconnects from Twitch.
+|Streamdeck/Transmitter Connected| Every time Stream Deck or Transmitter connects to SAMMI.
+|Streamdeck/Transmitter Disconnected| Every time Stream Deck or Transmitter disconnects from SAMMI.
 {:class='table table-secondary table-hover' }
 
 <hr>

--- a/doc_posts/_triggers/introduction.md
+++ b/doc_posts/_triggers/introduction.md
@@ -7,31 +7,31 @@ type: fullpage
 permalink: /triggers/introduction
 ---
 
-LioranBoard can trigger your buttons based on specific events (such as new Twitch subscriber, whenever you change scenes in OBS, when you start LioranBoard etc.). 
+SAMMI can trigger your buttons based on specific events (such as new Twitch subscriber, whenever you change scenes in OBS, when you start SAMMI etc.).
 
 ##### Add a new trigger to a button
-1. Right click on a button in your LioranBoard - **Edit Triggers** (or CTRL + double click). 
-2. Click on the **+** button and select the trigger type. 
+1. Right click on a button in SAMMI - **Edit Triggers** (or CTRL + double click).
+2. Click on the **+** button and select the trigger type.
 3. Fill out the fields and options for the selected trigger and press Save.
 
 ##### Get trigger data once button is triggered
-Once your button is triggered via a trigger, you can use [Trigger Pull Data]({{ "/commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the trigger event (such as viewer's name, their message, emotes, badge etc.).  
+Once your button is triggered via a trigger, you can use [Trigger Pull Data]({{ "/commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the trigger event (such as viewer's name, their message, emotes, badge etc.).
 
 ##### Queueable vs. non-queueable buttons
 If you right click on a button - **Edit Settings** and check `Add to Request Queue`, all triggers that come in while the button is still active (for example if you get two subscribers at the same time) will be put in a queue and the button will be reactivated as soon as it's ready again.\
 If you do not check `Add to Request Queue`, the button will ignore any triggers that come in while the button is active and discard them.
 
-{% include alert.html text="Does not apply if button overlap is enabled" type="warning" %} 
+{% include alert.html text="Does not apply if button overlap is enabled" type="warning" %}
 
 ##### Overlappable buttons
-If you right click on a button - **Edit Settings** and check `Allow Button Overlap`, multiple instances of the same button can be triggered at the same time (even if the previous button is still active).  
+If you right click on a button - **Edit Settings** and check `Allow Button Overlap`, multiple instances of the same button can be triggered at the same time (even if the previous button is still active).
 
 
-This is not something you want to enable for certain triggers attached to buttons controlling your OBS animations (for example, you probably don't want two subscriber animations to happen at the same time on your screen), but it can be useful for other events (for example for `!enter giveaway` chat trigger where a lot of users enter at the same time and you want to collect their names as quickly as possible without any queue). 
+This is not something you want to enable for certain triggers attached to buttons controlling your OBS animations (for example, you probably don't want two subscriber animations to happen at the same time on your screen), but it can be useful for other events (for example for `!enter giveaway` chat trigger where a lot of users enter at the same time and you want to collect their names as quickly as possible without any queue).
 
-##### Wild Cards 
+##### Wild Cards
 **Some trigger fields (such as Twitch chat messags trigger) accept wild cards.**\
-For example, you want your user to type a color in your chat. Instead of creating separate triggers for ALL possible colors, you can create one trigger that will accept a wild card in place of the specific color.  
+For example, you want your user to type a color in your chat. Instead of creating separate triggers for ALL possible colors, you can create one trigger that will accept a wild card in place of the specific color.
 
 
 A wild card <i class="fas fa-star-of-life fa-sm"></i> refers to a character that can be substituted for zero or more characters in a string. They are used to search for partial matches instead of exact ones.\
@@ -61,4 +61,4 @@ Please note this assumes there's a space before and after `word`.
 Want to capture only a single word after a specific keyword and ignore the rest of the text? Use these two triggers: `keyword * *` and `keyword *` (order matters!).\
 Now if you make your [Pull Wildcard]({{ "commands/trigger#pullwildcard" | relative_url }}) command pull the first (0) wildcard, it will always pull whatever word comes after `keyword` and ignore any additional text afterwards.
 
-{% include alert.html text='A single <i class="fas fa-star-of-life fa-sm"></i> in your Channel Points Message Trigger field allows for any message to trigger your button, but does not function as an actual wild card. Use <b>Trigger Pull Data</b> command to pull the whole message.' type="warning" %} 
+{% include alert.html text='A single <i class="fas fa-star-of-life fa-sm"></i> in your Channel Points Message Trigger field allows for any message to trigger your button, but does not function as an actual wild card. Use <b>Trigger Pull Data</b> command to pull the whole message.' type="warning" %}

--- a/doc_posts/_triggers/obs.md
+++ b/doc_posts/_triggers/obs.md
@@ -6,18 +6,18 @@ num: 4
 type: fullpage
 permalink: /triggers/obs
 ---
-LioranBoard can listen to all OBS events provided by OBS Websocket. 
+SAMMI can listen to all OBS events provided by OBS Websocket.
 
-#### Add a new OBS trigger 
-1. Right click on a button in your LioranBoard - **Edit Triggers** (or CTRL + double click). 
-2. Click on the **+** button and select **OBS Trigger**. 
-3. Choose the **Update Type**. 
+#### Add a new OBS trigger
+1. Right click on a button in SAMMI - **Edit Triggers** (or CTRL + double click).
+2. Click on the **+** button and select **OBS Trigger**.
+3. Choose the **Update Type**.
 4. Choose which OBS the trigger applies to (only if using multiple OBS)
 5. Optionally you can right click on a button - **Edit Settings** and check  `Add to Request Queue`, which acts as a button queue. If there is another trigger event while the button is still active, it will place is in the queue and reactivate the button as soon as it's ready again.
 <br>
 
 #### Retrieve OBS trigger event values
 1. In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command with an **empty pull value** to retrieve the whole object with all the provided data from OBS Websocket.
-2. Find the specified event in the [OBS Websocket documentation](https://github.com/obsproject/obs-websocket/blob/4.x-current/docs/generated/protocol.md#events) and check its response items. 
+2. Find the specified event in the [OBS Websocket documentation](https://github.com/obsproject/obs-websocket/blob/4.x-current/docs/generated/protocol.md#events) and check its response items.
 3. Use **[Get Object Variable]({{ "commands/object#setobjectvariable" | relative_url }})** command to retrieve the specific response item provided by OBS Websocket.
 

--- a/doc_posts/_triggers/twitch.md
+++ b/doc_posts/_triggers/twitch.md
@@ -8,24 +8,24 @@ type: fullpage
 permalink: /triggers/twitch
 ---
 
-LioranBoard can listen to Twitch events and automatically execute your buttons. For example, it can automatically trigger a button every time you get a new subscriber. 
+SAMMI can listen to Twitch events and automatically execute your buttons. For example, it can automatically trigger a button every time you get a new subscriber.
 
-#### Add a new trigger 
-1. Right click on a button in your LioranBoard - **Edit Triggers** (or CTRL + double click). 
-2. Click on the **+** button and select the Twitch trigger type. 
+#### Add a new trigger
+1. Right click on a button in SAMMI - **Edit Triggers** (or CTRL + double click).
+2. Click on the **+** button and select the Twitch trigger type.
 3. Fill out the fields and options for the selected trigger (read below) and press Save.
 4. Optionally you can right click on a button - **Edit Settings** and check  `Add to Request Queue`, which acts as a button queue. If there is another trigger event while the button is still active (for example if you get two subscribers at the same time), it will place is in the queue and reactivate the button as soon as it's ready again.
-4. In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the event (viewer's name, their message, emotes, badge etc.).   
+4. In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the event (viewer's name, their message, emotes, badge etc.).
 <br>
 
 
 #### Trigger Types
 
 ##### Chat
-Listens to all chat messages and triggers when specific conditions are met.\    
+Listens to all chat messages and triggers when specific conditions are met.\
 The message field comes with a prefilled `*`, which means it will allow ALL chat messages to come through. You can delete the `*` and use your own keyword.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Mod | Triggers only if a mod sends the message. |
 | Sub | Triggers only if a subscriber sends the message. |
@@ -33,13 +33,13 @@ The message field comes with a prefilled `*`, which means it will allow ALL chat
 | VIP | Triggers only if a VIP viewer sends the message. |
 | Founder | Triggers only if the viewer has founders badge. |
 Message | Chat message to listen to. Must be an exact match. Can include **[Wild Cards](introduction#wildcards)**. |
-| Case Sensitive | If the user message trigger should be case sensitive 
+| Case Sensitive | If the user message trigger should be case sensitive
 {:class='table table-primary' }
 
 {% include alert.html text="If two or more conditions are checked (such as Mod and Sub), <b>all</b> conditions must be met (user must be a mod and a subscriber). Create separate chat triggers for multiple conditions." type="warning" %}
 
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Viewer's username (all lowercase characters). |
 | Display Name | Viewer's display name (can contain uppercase characters). |
@@ -57,15 +57,15 @@ Message | Chat message to listen to. Must be an exact match. Can include **[Wild
 ##### Whispers
 Triggers for any new received whisper messages. Must use [Twitch Open Whispers]({{ "commands/twitch#openwhispers" | relative_url }}) command to enable whisper messages.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 |Message | Whisper message to listen to. Must be an exact match. Can include **[Wild Cards](introduction#wildcards)**. |
-| Case Sensitive | If the user message trigger should be case sensitive 
+| Case Sensitive | If the user message trigger should be case sensitive
 | Allow Empty Wildcard | Check to allow empty strings as valid results
 | Sent Messages | Whether you want the button to trigger for not only received, but also sent messages
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Sender User Name | Username of the user who sent the whisper. |
 | Sender Display Name | Display Name of the user who sent the whisper. |
@@ -86,7 +86,7 @@ Triggers for any new received whisper messages. Must use [Twitch Open Whispers](
 ##### New Follower
 Triggers for all new channel followers.
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Viewer's username (all lowercase characters). |
 | Display Name | Viewer's display name (can contain uppercase characters). |
@@ -96,12 +96,12 @@ Triggers for all new channel followers.
 
 <hr>
 
-##### Subscription 
-Listens to all new subscribers in your channel. 
+##### Subscription
+Listens to all new subscribers in your channel.
 
-{% include alert.html text="This trigger will send individual alerts for gifted subs. If you receive 5 gifted subs, 5 individual alerts will be sent by this trigger. If you want one single alert for gifted subs, see Community Gift Subs below." type="warning" %} 
+{% include alert.html text="This trigger will send individual alerts for gifted subs. If you receive 5 gifted subs, 5 individual alerts will be sent by this trigger. If you want one single alert for gifted subs, see Community Gift Subs below." type="warning" %}
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Tier 1 | Triggers for tier 1 subscriptions. |
 | Tier 2 | Triggers for tier 2 subscriptions. |
@@ -114,7 +114,7 @@ Listens to all new subscribers in your channel.
 | Month Range | Minimum and maximum amount of months the user must be suscribed for the event to trigger.
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Viewer's or gifter's username (all lowercase characters). |
 | Display Name | Viewer's or gifter's display name (can contain uppercase characters). |
@@ -132,11 +132,11 @@ Listens to all new subscribers in your channel.
 <hr>
 
 ##### Community Gift Subs
-Triggers for all community gift subscriptions. 
+Triggers for all community gift subscriptions.
 
-{% include alert.html text="This will not send the names of who the subs were gifted to. If you want to retrieve all the names of the gifted subs, you need to also use Subscriber trigger" type="warning" %} 
+{% include alert.html text="This will not send the names of who the subs were gifted to. If you want to retrieve all the names of the gifted subs, you need to also use Subscriber trigger" type="warning" %}
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Tier 1 | Triggers for tier 1 gifted subscriptions. |
 | Tier 2 | Triggers for tier 2 gifted subscriptions. |
@@ -145,7 +145,7 @@ Triggers for all community gift subscriptions.
 | Maximum | Specify the maximum amount of gifted subscribers to trigger the button.
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Gifter's username. Returns `ananonymousgifter` for anonymous gifters. |
 | Display Name | Gifter's display name. Returns `AnAnonymousGifter` for anonymous gifters. |
@@ -159,13 +159,13 @@ Triggers for all community gift subscriptions.
 ##### Bits
 Listens to all bit events in your stream.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Minimum |  Specify the minimum amount of bits to trigger the button. |
 | Maximum |  Specify the maximum amount of bits to trigger the button.
 {:class='table table-primary table-hover' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Viewer's username. |
 | User ID | Viewer's user ID. |
@@ -177,15 +177,15 @@ Listens to all bit events in your stream.
 <hr>
 
 ##### Raid
-Listens to all raid events in your stream. 
+Listens to all raid events in your stream.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Minimum | Specify the minimum amount of raiders to trigger the button. |
 | Maximum | Specify the maximum amount of raiders to trigger the button.
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Raider's username. |
 | Display Name | Raider's or host's display name. |
@@ -196,15 +196,15 @@ Listens to all raid events in your stream.
 <hr>
 
 ##### Host
-Listens to all host events in your stream. Twitch does not send alerts for host events with less than three viewers. 
+Listens to all host events in your stream. Twitch does not send alerts for host events with less than three viewers.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Minimum | Specify the minimum amount of host's viewers to trigger the button. |
 | Maximum | Specify the maximum amount of host's viewers to trigger the button.
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Display Name | Host's display name. |
 | Amount | Amount of host's viewers. |
@@ -213,20 +213,20 @@ Listens to all host events in your stream. Twitch does not send alerts for host 
 <hr>
 
 ##### Channel Points
-Listens to all custom channel points redeems. 
+Listens to all custom channel points redeems.
 
-In order for LioranBoard to listen to Channel Point triggers, make sure the scope to listen to Channel Points has been enabled in LioranBoard. Twitch and the Transmitter also has to be connected. 
+In order for SAMMI to listen to Channel Point triggers, make sure the scope to listen to Channel Points has been enabled in SAMMI. Twitch and the Transmitter also has to be connected.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Redemption Name | Select the name of the redemption from the list or type in manually. A single `*` allows all redeems to trigger the button (does not act as a wildcard). |
 | User Input Required | Whether the particular redemption requires viewers to enter text when redeemed
-| Case Sensitive | If the user message trigger should be case sensitive 
+| Case Sensitive | If the user message trigger should be case sensitive
 |User Input | User input if the redemption requires requires viewers to enter text when redeemed (use `*` to accept all user messages). Can include **[Wild Cards](introduction#wildcards)**.
 | Allow Empty Wildcard | Check to allow empty strings as valid results
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | User Name | Viewer's username. |
 | Display Name | Viewer's display name. |
@@ -242,14 +242,14 @@ In order for LioranBoard to listen to Channel Point triggers, make sure the scop
 <hr>
 
 ##### Prediction
-Triggers for all prediction events. 
+Triggers for all prediction events.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 |Type |Type of the prediction event to trigger the button <br/> **Created** = when a new prediction is created <br/>  **Voted** = when a current prediction receives a new vote, <br/> **Locked** = when a current prediction ends and no more votes are accepted, <br/> **Resolved** - when the broadcaster chooses an outcome for the prediction
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 |Duration|Duration of the prediction
 |Event|
@@ -258,20 +258,20 @@ Triggers for all prediction events.
 |Vote Total|Total prediction votes
 |Outcome 1 Info|An object containing prediction's outcome 1 information
 |Outcome 2 Info|An object containing prediction's outcome 2 information
-|Winning Outcome|Winning outcome 
+|Winning Outcome|Winning outcome
 {:class='table table-secondary table-hover' }
 
 <hr>
 
 ##### Poll
-Triggers for all poll events. 
+Triggers for all poll events.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 |Type | Type of the poll event to trigger the button <br/> **Created** = when a new poll is created <br/>  **Voted** = when a current poll receives a new vote, <br/> **Ended** = when a current poll ends and no more votes are accepted, <br/> **Archived** - when a current poll is archived (and disappears from Twitch chat)
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 |Choice Amount|Number of poll choices
 |Duration|Duration of the poll
@@ -294,17 +294,17 @@ Triggers for all poll events.
 ##### Hype Train
 Triggers for all new hype train events.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
-|Type | Dropdown | Type of the hype train event to trigger the button <br/> Approaching = when a new hype train is about to begin <br/>  **Started** = when a new hype train has started, <br/> **Conductor Update** = when a hype train receives new points (for example if someone subscribes while it's ongoing), <br/> **Level up** - when a hype train levels up <br/> **Ended** - when a hype train has ended,<br/>  **Cooldown expired** - when a previous hype train's cooldown has expired and a new hype train can begin 
+|Type | Dropdown | Type of the hype train event to trigger the button <br/> Approaching = when a new hype train is about to begin <br/>  **Started** = when a new hype train has started, <br/> **Conductor Update** = when a hype train receives new points (for example if someone subscribes while it's ongoing), <br/> **Level up** - when a hype train levels up <br/> **Ended** - when a hype train has ended,<br/>  **Cooldown expired** - when a previous hype train's cooldown has expired and a new hype train can begin
 {:class='table table-primary' }
 
 <hr>
 
 ##### Moderation
-Triggers for any of the selected moderation events. Due to some back-end changes from Twitch, listening to some moderation events currently do not work. 
+Triggers for any of the selected moderation events. Due to some back-end changes from Twitch, listening to some moderation events currently do not work.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 Type | Dropdown | Type of the event to trigger the button
 {:class='table table-primary' }

--- a/doc_posts/_triggers/youtube.md
+++ b/doc_posts/_triggers/youtube.md
@@ -6,14 +6,14 @@ num: 3
 type: fullpage
 permalink: /triggers/youtube
 ---
-LioranBoard can listen to all YouTube Live events provided by the YouTube API automatically execute your buttons. For example, it can automatically trigger a button every time you get a new subscriber.
+SAMMI can listen to all YouTube Live events provided by the YouTube API automatically execute your buttons. For example, it can automatically trigger a button every time you get a new subscriber.
 
-#### Add a new trigger 
-1. Right click on a button in your LioranBoard - **Edit Triggers** (or CTRL + double click). 
+#### Add a new trigger
+1. Right click on a button in SAMMI - **Edit Triggers** (or CTRL + double click).
 2. Click on the **+** button and select any YouTube Trigger.
 3. Fill out the fields and options for the selected trigger (read below) and press Save.
 4. Optionally you can right click on a button - **Edit Settings** and check  `Add to Request Queue`, which acts as a button queue. If there is another trigger event while the button is still active (for example if you get two subscribers at the same time), it will place is in the queue and reactivate the button as soon as it's ready again.
-4. In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the event (viewer's name, their message, channel ID etc.).   
+4. In your button commands, use [Trigger Pull Data]({{ "commands/trigger#triggerpulldata" | relative_url }}) command to retrieve all the provided information from the event (viewer's name, their message, channel ID etc.).
 <br>
 
 
@@ -23,20 +23,20 @@ LioranBoard can listen to all YouTube Live events provided by the YouTube API au
 Listens to all chat messages and triggers when specific conditions are met.\
 The message field comes with a prefilled `*`, which means it will allow ALL chat messages to come through. You can delete the `*` and use your own keyword.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Mod | Triggers only if a mod sends the message. |
 | Member | Triggers only if a Member sends the message. |
 | Broadcaster | Triggers only if the broadcast themselves sends the message. |
 | Verified | Triggers only if a verified viewer sends the message. |
 Message | Chat message to listen to. Must be an exact match. Can include **[Wild Cards](introduction#wildcards)**. |
-| Case Sensitive | If the user message trigger should be case sensitive 
+| Case Sensitive | If the user message trigger should be case sensitive
 {:class='table table-primary' }
 
 {% include alert.html text="If two or more conditions are checked (such as mod and subscriber), <b>all</b> conditions must be met (user must be a mod and a subscriber). Create separate chat triggers for multiple conditions." type="warning" %}
 
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Display Name | Viewer's display name. |
 | User ID | Viewer's user ID. |
@@ -56,7 +56,7 @@ Message | Chat message to listen to. Must be an exact match. Can include **[Wild
 ##### Subscriber
 Triggers for all new channel subscribers.
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Display Name | Viewer's display name. |
 | User ID | Viewer's user ID. |
@@ -67,14 +67,14 @@ Triggers for all new channel subscribers.
 <hr>
 
 ##### Member
-Listens to all new members (formerly sponsors) in your channel. 
+Listens to all new members (formerly sponsors) in your channel.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Months |Minimum and maximum amount of months the viewer must be a member for the event to trigger. |
 {:class='table table-primary' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Display Name | Viewer's display name. |
 | User ID | Viewer's user ID. |
@@ -82,7 +82,7 @@ Listens to all new members (formerly sponsors) in your channel.
 | Picture URL | Viewer's channel picture URL |
 | Chat ID | Chat ID where the message originated from|
 | Message | Viewer's message (only applies for member renewal events where the viewers can attach a message) |
-| Level Name | Your member's level name | 
+| Level Name | Your member's level name |
 |Months | How long the viewer has been your member (only applies for member renewal events)
 {:class='table table-secondary table-hover' }
 
@@ -91,13 +91,13 @@ Listens to all new members (formerly sponsors) in your channel.
 ##### Super Chat
 Listens to all Super Chat events in your stream.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Minimum |  Specify the minimum amount of micros to trigger the button. |
 | Maximum |  Specify the maximum amount of micros to trigger the button.
 {:class='table table-primary table-hover' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Display Name | Viewer's display name. |
 | User ID | Viewer's user ID. |
@@ -105,10 +105,10 @@ Listens to all Super Chat events in your stream.
 | Picture URL | Viewer's channel picture URL |
 | Chat ID | Chat ID where the message originated from|
 | Message | Viewer's message |
-| Amount | The purchase amount in Micros. If the purchase amount is $1, the value will be 1000000. 
+| Amount | The purchase amount in Micros. If the purchase amount is $1, the value will be 1000000.
 | Amount as String | A string, like $1.00, that contains the purchase amount and currency.
 | Currency | The currency in which the purchase was made. The value is an ISO 4217 currency code.
-| Tier | The tier for the paid message. The tier is based on the amount of money spent to purchase the message. 
+| Tier | The tier for the paid message. The tier is based on the amount of money spent to purchase the message.
 {:class='table table-secondary table-hover' }
 
 <hr>
@@ -116,13 +116,13 @@ Listens to all Super Chat events in your stream.
 ##### Super Sticker
 Listens to all Super Sticker events in your stream.
 
-| Condition | Explanation | 
+| Condition | Explanation |
 |-------|--------|
 | Minimum |  Specify the minimum amount of micros to trigger the button. |
 | Maximum |  Specify the maximum amount of micros to trigger the button.
 {:class='table table-primary table-hover' }
 
-| Pull Data Value | Explanation | 
+| Pull Data Value | Explanation |
 |-------|--------|
 | Display Name | Viewer's display name. |
 | User ID | Viewer's user ID. |
@@ -130,11 +130,11 @@ Listens to all Super Sticker events in your stream.
 | Picture URL | Viewer's channel picture URL |
 | Chat ID | Chat ID where the message originated from|
 | Message | Viewer's message |
-| Amount | The purchase amount in Micros. If the purchase amount is $1, the value will be 1000000. 
+| Amount | The purchase amount in Micros. If the purchase amount is $1, the value will be 1000000.
 | Amount as String | A string, like $1.00, that contains the purchase amount and currency.
 | Currency | The currency in which the purchase was made. The value is an ISO 4217 currency code.
-| Sticker ID | A unique ID that identifies the sticker image. Note that the image is only displayed as part of the Super Sticker message when users view the chat window on YouTube. However, the image URL is not available via LioranBoard. 
-| Sticker Text  | A text string that describes the sticker. 
+| Sticker ID | A unique ID that identifies the sticker image. Note that the image is only displayed as part of the Super Sticker message when users view the chat window on YouTube. However, the image URL is not available via SAMMI.
+| Sticker Text  | A text string that describes the sticker.
 {:class='table table-secondary table-hover' }
 
 <hr>

--- a/doc_posts/_troubleshooting-buttons/button-crashes.md
+++ b/doc_posts/_troubleshooting-buttons/button-crashes.md
@@ -3,8 +3,8 @@ title: Button crashes
 num: 2
 ---
 
-If you’re using the latest LioranBoard version (2.07.x), the crash log will show you which button and command made it crash. On older versions, it’s a bit harder to decipher. You can update via the settings button in the bottom left of the receiver.
+If you’re using the latest SAMMI version (2.07.x), the crash log will show you which button and command made it crash. On older versions, it’s a bit harder to decipher. You can update via the settings button in the bottom left of the receiver.
 
 {% include image.html w="75" src="https://i.imgur.com/3lmSCMi.png" alt="Crash error example" external="true" %}
 
-Be aware that the crash log tells you what command crashed LioranBoard, but the error could have been made in a command that executed earlier! Use that information (and what the actual error says) to troubleshoot using the tips in the next section.
+Be aware that the crash log tells you what command crashed SAMMI, but the error could have been made in a command that executed earlier! Use that information (and what the actual error says) to troubleshoot using the tips in the next section.

--- a/doc_posts/_troubleshooting-buttons/button-does-nothing.md
+++ b/doc_posts/_troubleshooting-buttons/button-does-nothing.md
@@ -10,7 +10,7 @@ Unless you’re triggering the button by pressing it on the stream deck, it’s 
 - Click ‘Active Buttons’ in the receiver main window to see whether the button ID pops up there. If the button doesn’t have any delays or wait commands this will be a quick flash, but you should still be able to see it.
 
 #### Possibility A: The button did not trigger
-Your button not triggering at all could have three causes: either your button trigger is incorrect, the button is being blocked somehow, or LioranBoard doesn’t receive the trigger at all.
+Your button not triggering at all could have three causes: either your button trigger is incorrect, the button is being blocked somehow, or SAMMI doesn’t receive the trigger at all.
 
 *Check whether your trigger is correct*
 
@@ -28,10 +28,10 @@ Your button not triggering at all could have three causes: either your button tr
 |Gift Subscription | Twitch sends two events when someone gifts multiple subs (aka ‘community gifts’). If you want to receive a single trigger when someone gifts 5 subs, add a Twitch Community Gift Subs trigger. If you want to receive 5 triggers when someone gifts 5 subs, add a Twitch Subscription trigger and allow community gifts. |
 {:class='table table-primary'}
 
-*Check whether LioranBoard is receiving the trigger*
+*Check whether SAMMI is receiving the trigger*
 
 - You cannot test via a third party such as StreamLabs or StreamElements. You should test via the test buttons in the transmitter or via Twitch.
-- Make sure whatever is sending your trigger is connected to LioranBoard. You can see this in the bottom left of the receiver main window. Twitch Subs, Channel Points etc. arrive via the transmitter! 
+- Make sure whatever is sending your trigger is connected to SAMMI. You can see this in the bottom left of the receiver main window. Twitch Subs, Channel Points etc. arrive via the transmitter!
 - Make sure you’re listening for the triggers in the Twitch Connections window.
 
 ##### Common issues with specific triggers:
@@ -42,19 +42,18 @@ Your button not triggering at all could have three causes: either your button tr
 |OBS trigger | If you can’t connect or it disconnects every time, check Common Issues in Troubleshooting. |
 {:class='table table-primary' }
 
-{% include image.html w="100" src="https://i.imgur.com/gdSzRl1.png" alt="Comunication between Twitch and Lioranboard" type="image" external="true" %}
+{% include image.html w="100" src="https://i.imgur.com/gdSzRl1.png" alt="Comunication between Twitch and SAMMI" type="image" external="true" %}
 
 *Check whether the button is being blocked*
 
-If you’re sure LioranBoard is receiving the trigger and the trigger on your button is set up correctly, your button may be blocked. A button could be blocked for three reasons:
+If you’re sure SAMMI is receiving the trigger and the trigger on your button is set up correctly, your button may be blocked. A button could be blocked for three reasons:
 
 - It is still active, for example because of a ‘Wait’ command. You can manually clear active buttons via the ‘Active Buttons’ window, or change the button settings to allow queues or overlap.
 - It has a group ID and another button in that group is still active. Same as above applies.
 - You used the Block Button/Group command on its ID. Make sure to unblock it first.
 
-If you can’t figure out why the button is blocked, try restarting LioranBoard. That should allow you to start fresh.
+If you can’t figure out why the button is blocked, try restarting SAMMI. That should allow you to start fresh.
 
 #### Possibility B: The button did trigger
 
 If your button triggered when it should have but nothing happened, that means something is wrong with your commands. Check the ‘Button doesn’t do what you want’ section below.
-

--- a/doc_posts/_troubleshooting-buttons/button-not-work.md
+++ b/doc_posts/_troubleshooting-buttons/button-not-work.md
@@ -20,7 +20,7 @@ If you see the word ‘undefined’ (in error messages, crashes, text sources, c
 
 #### Variables
 
-Variables, arrays and objects are a fundamental part of LioranBoard. You need to know how to use them to unlock the full potential of LB. Please read the variable introduction about how to use them and how to use the [White and Yellow Boxes]({{ "commands/variables#whitevsyellowboxforparameters" | relative_url }}). if you are not sure.
+Variables, arrays and objects are a fundamental part of SAMMI. You need to know how to use them to unlock the full potential of LB. Please read the variable introduction about how to use them and how to use the [White and Yellow Boxes]({{ "commands/variables#whitevsyellowboxforparameters" | relative_url }}). if you are not sure.
 
 #### Showing previous information, results only work after the second press or actions are being made in the incorrect order (or at the same time).
 
@@ -28,7 +28,7 @@ There is probably a problem with your delays (or wait commands, see Common Error
 
 #### Issues with Filters and Sources
 
-Check whether you are connected to OBS. Check Common Issues in Troubleshooting. If the source is inside a group, try taking it out to see if that makes a difference. The OBS websocket has a lot of issues working with groups, so if you use groups and LioranBoard cannot find them or work correctly with them, consider using nested scenes instead.
+Check whether you are connected to OBS. Check Common Issues in Troubleshooting. If the source is inside a group, try taking it out to see if that makes a difference. The OBS websocket has a lot of issues working with groups, so if you use groups and SAMMI cannot find them or work correctly with them, consider using nested scenes instead.
 
 #### Errors with Commands
 
@@ -44,5 +44,5 @@ Check whether you are connected to OBS. Check Common Issues in Troubleshooting. 
 |Source Change Volume/Motion: Source Volume|You need to add a number between 0 and 1. This number does NOT match with the numbers in LB1. You can figure out what number you need by going into OBS, clicking any cog in your audio mixer and selecting Advanced Audio Properties. Check the box above the Volume % column, and read the % from there. If it says 50%, you need to enter 0.5|
 |Trigger OBS Hotkey Sequence|You shouldn’t write the exact key you want to press, but the OBS name for that key. Check the documentation.|
 |Trigger Button|If you are auto-triggering the button, turn the queue on (in the button and in the command). The ‘hidden delay’ field cannot be left blank. |
-|Sound Effects|LioranBoard sound goes through the default output device of your pc when LB is opened. If you want to change where you want to hear LioranBoard (or use an audio cable), change to that device before launching LioranBoard. Once opened, you can change the default output device (back) to whatever you want and it will not affect LioranBoard.|
+|Sound Effects|SAMMI sound goes through the default output device of your pc when LB is opened. If you want to change where you want to hear SAMMI (or use an audio cable), change to that device before launching SAMMI. Once opened, you can change the default output device (back) to whatever you want and it will not affect SAMMI.|
 {:class='table table-primary' }

--- a/doc_posts/_troubleshooting-common/obs-connection.md
+++ b/doc_posts/_troubleshooting-common/obs-connection.md
@@ -9,20 +9,20 @@ You can try these steps to troubleshoot your OBS Websocket connection to LB:
 Try completely reinstalling the plugin. Make sure you have the latest version.\
 You can check whether your OBS websocket is correctly installed by going to OBS-Tools-Websockets Server Settings.
 - **Run as administrator**\
-Try running LioranBoard as administrator. Right click on LioranBoard and select `Run as administrator`.
+Try running SAMMI as an administrator. Right click on the SAMMI launch file and select `Run as administrator`.
 - **Check your firewall and antivirus**\
 Make sure your firewall is not blocking LB.\
 You can try [temporarily disabling your antivirus/firewall](https://support.microsoft.com/en-us/windows/turn-off-defender-antivirus-protection-in-windows-security-99e6004f-c54c-8509-773c-a4d776b77960) or [adding an exception](https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26) to allow the app through.
 - **Check OBS websocket password**\
-Your passwords in OBS-Tools-Websockets Server Settings and LioranBoard-OBS Connections need to match. If you do not use a password, uncheck Enable authentication.
+Your passwords in OBS-Tools-Websockets Server Settings and SAMMI-OBS Connections need to match. If you do not use a password, uncheck Enable authentication.
 - **Change Ports**\
-Change the port of OBS websocket (both in OBS and LioranBoard) to a new one, for example 4445.
+Change the port of OBS websocket (both in OBS and SAMMI) to a new one, for example 4445.
 - **Try Non Blocking Connection**\
-In your LioranBoard, go to OBS Connections and check/uncheck non blocking connection.
+In SAMMI, go to OBS Connections and check/uncheck non blocking connection.
 - **Change IP connection**\
 Normally you use 127.0.0.1 to connect to OBS, but you can try local IP as well.
 1. Launch command line (cmd.exe) and run `ipconfig` command.
 2. Note down your IPv4 address (it will start with `192.168`).
-3. Go to LioranBoard-OBS Connection and change the IP address.
+3. Go to SAMMI-OBS Connection and change the IP address.
 **Try connecting using other means**\
 You can try a chrome extension [Simple Websocket Client](https://chrome.google.com/webstore/detail/simple-websocket-client/pfdhoblngboilpfeibdedpjgfnlcodoo) to check if you can make a connection in the first place.

--- a/doc_posts/_troubleshooting-common/twitch-connection.md
+++ b/doc_posts/_troubleshooting-common/twitch-connection.md
@@ -4,37 +4,37 @@ num: 0
 ---
 
 #### Getting an ERR_BADAUTH error
-Your auth token probably expired. 
-1. In your LioranBoard, go to Twitch Connections-Revoke Token.
+Your auth token probably expired.
+1. In SAMMI, go to Twitch Connections-Revoke Token.
 2. Link your Twitch account again by pressing Open URL.
 
 #### Twitch Alerts don't work
 
 **Check your Transmitter connection**\
-Make sure your Transmitter is running is connected to LioranBoard (the status should be green for Transmitter in your left bottom corner in LioranBoard).
-In your Transmitter it must say <strong>Pubsub: {% include colored_text.html color="green" text="Connected" %}<strong>.  
+Make sure your Transmitter is running is connected to SAMMI (the status should be green for Transmitter in your left bottom corner in SAMMI).
+In your Transmitter it must say <strong>Pubsub: {% include colored_text.html color="green" text="Connected" %}<strong>.
 
-**Try triggering a test alert from your Transmitter**  
+**Try triggering a test alert from your Transmitter**
 In your Transmitter, go to Twitch Triggers tab and press any of the test buttons.\
-A small yellow notification message should pop up at the bottom of your LioranBoard. 
+A small yellow notification message should pop up at the bottom of SAMMI.
 
-- *I do not see the message at all* - your Transmitter is not connected to LioranBoard. You might be running a wrong version or duplicate instance of your Transmitter. 
+- *I do not see the message at all* - your Transmitter is not connected to SAMMI. You might be running a wrong version or duplicate instance of your Transmitter.
 - *I see the message, but buttons do not trigger at all* - your button triggers are set up wrong. Follow the guide in our Triggers section.
 - *I see the message, buttons trigger, but nothing happens in OBS* - You're either not connected to OBS or your commands are wrong.
 
 #### Twitch: Send message doesn't work
 
 **Check you're connected to Twitch Chat**\
-In LioranBoard-Twitch Connections, press Connect Twitch Chat and check `Auto connect to Twitch Chat`, otherwise you will need to press this button every time you launch LioranBoard.
+In SAMMI-Twitch Connections, press Connect Twitch Chat and check `Auto connect to Twitch Chat`, otherwise you will need to press this button every time you launch SAMMI.
 
 **Check you're sending the message to the right channel**
-- If you have only a single Twitch account linked to your LioranBoard, leave the channel name empty.\
+- If you have only a single Twitch account linked to SAMMI, leave the channel name empty.\
   {% include image.html w="75" src="chat-message.png" alt="Chat Message with single Twitch account linked" %}
-- If you have multiple Twitch accounts linked to your LioranBoard, correctly fill out the channel name with your Twitch channel name (all lowercase characters)\
+- If you have multiple Twitch accounts linked to SAMMI, correctly fill out the channel name with your Twitch channel name (all lowercase characters)\
   {% include image.html w="75" src="chat-message2.png" alt="Chat Message with multiple Twitch accounts linked" %}
 
 **Check you're not sending too many messages**\
-If you send too many messages in a short period of time from LioranBoard, Twitch might temporarily block you from sending more.
+If you send too many messages in a short period of time from SAMMI, Twitch might temporarily block you from sending more.
 
 #### Twitch Chat Whispers do not work
 
@@ -42,5 +42,5 @@ If you send too many messages in a short period of time from LioranBoard, Twitch
 You can send a whisper by using Twitch: Send Message command and putting `/w username` in the message field.
 
 **Request Verified Bot Status**\
-Sometimes Twitch will block your account from sending whispers from 3rd party applications (such as LioranBoard).\
+Sometimes Twitch will block your account from sending whispers from 3rd party applications (such as SAMMI).\
 You can try filling out the [IRC Command and Message Rate form](https://dev.twitch.tv/limit-increase) to verify your bot.

--- a/doc_posts/_youtube-commands/ban-unban.md
+++ b/doc_posts/_youtube-commands/ban-unban.md
@@ -8,15 +8,15 @@ Ban or unban a viewer. Broadcast must be live and connection status must be `lis
 Provide either their [channel ID](https://commentpicker.com/youtube-channel-id.php) or chat display name.\
 You can only unban a permanently banned user. If you want to remove a timeout, select `temporary ban` with `0 duration` (which will override the original timeout).
 
-{% include alert.html text="If the viewer does not talk during your stream, there is no way for LioranBoard to associate their display name with their channel ID. In that case you must provide their channel ID." type="warning" %} 
+{% include alert.html text="If the viewer does not talk during your stream, there is no way for SAMMI to associate their display name with their channel ID. In that case you must provide their channel ID." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |displayName|String|Viewer's chat display name. Do not provide channel id if you already provided a display name.|
 |channelid | string | Viewer's [channel ID](https://commentpicker.com/youtube-channel-id.php). Do not provide a display name if you already provided a channel ID.
-|type|Dropdown|Whether you want to ban or unban the user. You can only unban a permanently banned user. 
+|type|Dropdown|Whether you want to ban or unban the user. You can only unban a permanently banned user.
 |permanent|Boolean| Whether you want your ban to be permanent or temporary (=timeout).
-|duration|Int|Duration (if you selected temporary ban) in minutes. Use 0 if you want to un-timeout a user. 
+|duration|Int|Duration (if you selected temporary ban) in minutes. Use 0 if you want to un-timeout a user.
 {:class='table table-secondary w-auto table-hover data-toggle='table' text-break' }
 
 

--- a/doc_posts/_youtube-commands/get-member-info.md
+++ b/doc_posts/_youtube-commands/get-member-info.md
@@ -3,15 +3,15 @@ title: Get Member Info
 num: 8
 ---
 
-{% include alert.html text="This command is not available now. Waiting for additional scope approval from Google." type="danger" %} 
+{% include alert.html text="This command is not available now. Waiting for additional scope approval from Google." type="danger" %}
 
 `Command: Send to Extension - YouTube Live Get Member Info`\
 Retrieves information about a member (same as Twitch subscriber) of your channel. Connection status must be `ready`.\
 Provide either their [channel ID](https://commentpicker.com/youtube-channel-id.php) or chat display name.
 
-{% include alert.html text="If the member does not talk during your stream, there is no way for LioranBoard to associate their display name with their channel ID. In that case you must provide their channel ID." type="warning" %} 
+{% include alert.html text="If the member does not talk during your stream, there is no way for SAMMI to associate their display name with their channel ID. In that case you must provide their channel ID." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |displayName|String|Viewer's chat display name. Do not provide channel id if you already provided a display name.|
 |channelid | string | Viewer's [channel ID](https://commentpicker.com/youtube-channel-id.php). Do not provide a display name if you already provided a channel ID.

--- a/doc_posts/_youtube-commands/get-sub-status.md
+++ b/doc_posts/_youtube-commands/get-sub-status.md
@@ -7,9 +7,9 @@ num: 9
 Checks whether your viewer is subscribed to (follows) your channel. Connection status must be `ready`.\
 Provide either their [channel ID](https://commentpicker.com/youtube-channel-id.php) or chat display name.\
 
-{% include alert.html text="If the member does not talk during your stream, there is no way for LioranBoard to associate their display name with their channel ID. In that case you must provide their channel ID." type="warning" %} 
+{% include alert.html text="If the member does not talk during your stream, there is no way for SAMMI to associate their display name with their channel ID. In that case you must provide their channel ID." type="warning" %}
 
-| Box Name | Type | Description | 
+| Box Name | Type | Description |
 |-------|--------|--------
 |displayName|String|Viewer's chat display name. Do not provide channel id if you already provided a display name.|
 |channelid | string | Viewer's [channel ID](https://commentpicker.com/youtube-channel-id.php). Do not provide a display name if you already provided a channel ID.

--- a/doc_posts/_youtube-general/quotas.md
+++ b/doc_posts/_youtube-general/quotas.md
@@ -4,11 +4,11 @@ num: 2
 ---
 
 YouTube Live API uses a quota system to ensure that developers use the service as intended and do not create API clients that unfairly reduce service quality or limit access for others.\
-LioranBoard has been given a global quota of 8000000 units/day. This is quota for all users combined using the integration.\
-Individual users have a **max quota of 500 units/minute**. **This in no way means you should use up all your quota every minute**, it's rather a hard limit to prevent spam. It might be a subject to change later depending on how many users use the integration and if we can get a higher quota approved by YouTube.  
+SAMMI has been given a global quota of 8000000 units/day. This is quota for all users combined using the integration.\
+Individual users have a **max quota of 500 units/minute**. **This in no way means you should use up all your quota every minute**, it's rather a hard limit to prevent spam. It might be a subject to change later depending on how many users use the integration and if we can get a higher quota approved by YouTube.
 
 
-Find the quota cost table below. YouTube Live API does not provide this information for some of the commands. Those were calculated by my own observations and might be a subject to change at anytime.  
+Find the quota cost table below. YouTube Live API does not provide this information for some of the commands. Those were calculated by my own observations and might be a subject to change at anytime.
 
 
 *Max per minute is a rough estimate as it depends on how often the integration polls new chat messages per minute.*
@@ -17,16 +17,16 @@ Find the quota cost table below. YouTube Live API does not provide this informat
 |-------|--------|--------
 |Get chat messages|  5 units | N/A | Chat messages are polled based on the amount of viewers or whatever YouTube API dictates. They can cost anywhere from 30-150 units/minute.|
 |Send a chat message| 20 units | 23 | Group up your chat messages or show them on screen instead to save your quota.
-|Ban a user |200 units| 2 | This is a very expensive endpoint. It's recommended to ban users manually if you need to go through a lot of names.| 
-|Update broadcast |50 units| 9 | 
+|Ban a user |200 units| 2 | This is a very expensive endpoint. It's recommended to ban users manually if you need to go through a lot of names.|
+|Update broadcast |50 units| 9 |
 |List Categories| 1 unit | N/A | Categories are retrieved once every streaming session.|
 |Get Channel Stats |1 unit | N/A | Your channel stats are retrieved once every streaming session. |
 |Get Broadcast Stats |1 unit | 1 | Get Broadcast Stats is automatically polled every minute by the integration. Using the LB command does not increase the cost.|
 |Get Subscribers|1 unit | 470 | Checking for new subscribers is done once per minute. Using the `Check Subscriber Status` command will cost you an additional 1 unit.
 |Get Member Info |2 units|235|
-{:class='table table-primary w-auto table-hover data-toggle='table'} 
+{:class='table table-primary w-auto table-hover data-toggle='table'}
 
-If you run out of your individual quota, you will get an alert message `You have exceeded your user quota. Slow down!` in LioranBoard and will not be able to listen to new events or use any commands for 1 minute before your quota is replenished. You might need to reload the Transmitter as well. 
+If you run out of your individual quota, you will get an alert message `You have exceeded your user quota. Slow down!` in SAMMI and will not be able to listen to new events or use any commands for 1 minute before your quota is replenished. You might need to reload the Transmitter as well.
 
 
 

--- a/doc_posts/_youtube-transmitter/tab-features.md
+++ b/doc_posts/_youtube-transmitter/tab-features.md
@@ -18,4 +18,4 @@ Shows all available broadcast categories.
 {% include image.html w="75" src="yt-tsl-categories.png"  %}
 
 #### Test events
-You can use the test buttons to send fake events to LioranBoard. They will mimic the real events YouTube sends. Some buttons have options you can fill out as well.
+You can use the test buttons to send fake events to SAMMI. They will mimic the real events YouTube sends. Some buttons have options you can fill out as well.

--- a/doc_posts/_youtube-triggers/general.md
+++ b/doc_posts/_youtube-triggers/general.md
@@ -3,11 +3,11 @@ title: "General"
 num: 1
 ---
 
-Once your status changes to `Listening`, LioranBoard will automatically start listening to all the following events. (No events are delivered if the stream is offline and status is `Ready`.)\
+Once your status changes to `Listening`, SAMMI will automatically start listening to all the following events. (No events are delivered if the stream is offline and status is `Ready`.)\
 The events are polled every X seconds. The frequency depends on how many current viewers your stream has. 10 seconds for less than 3 viewers, 5 seconds for less than 10 viewers and 2 seconds (or whatever YouTube API dictates) for 10+ viewers.
 
 **Sending test events**
-You can test all available events via Transmitter in your YouTube Live tab. The test buttons will mimic real events that YouTube API sends. There are some options you can fill out as well. 
+You can test all available events via Transmitter in your YouTube Live tab. The test buttons will mimic real events that YouTube API sends. There are some options you can fill out as well.
 
 **Replaying events**
 You can enable Event Replays via Transmitter in your YouTube Live tab. All new recent events (max 15) will be logged and available from the dropdown menu to either replay them or view the raw payload YouTube sends.


### PR DESCRIPTION
This PR changes a bunch of old names to the new one. However, it does not change all of them. Any reference to a lioran folder was untouched. I don't know if the folder name will be changed so I left it alone to avoid confusion.

Links were also untouched. I'm new to jeykll but I'm pretty sure you are not supposed to use absolute links. I left those alone in case there was a reason for them.

I also removed some extra spaces and changed a little wording here and there. You should also update the about section of the repo as it still uses the old name.