### PR TITLE
match command name and remove unrelated content

### DIFF
--- a/doc_posts/_commands-number/hex_to_number.md
+++ b/doc_posts/_commands-number/hex_to_number.md
@@ -1,11 +1,9 @@
 ---
-title: "Hex to Number"
+title: "Hex String to Number"
 num: 3
 ---
 
 Converts a hexadecimal string into a real (decimal) number. 
-
-{% include alert.html text="Pressing reset button automatically clears all variables." type="info" %}  
 
 | Box Name | Type | Description | 
 |-------|--------|--------|


### PR DESCRIPTION
'Hex To Number' changed to 'Hex String To Number' to match command name in SAMMI. Also removed an apparently unrelated line about clicking a nonexistant "reset button".