### PR TITLE
Update obs-sound-play.md

### DIFF
--- a/doc_posts/_commands-sounds/obs-sound-play.md
+++ b/doc_posts/_commands-sounds/obs-sound-play.md
@@ -5,7 +5,7 @@ redirect_from:
   - commands/2
 ---
 
-Plays a selected sound file. Only .ogg files are supported.
+Plays a selected sound file. Files must be in Vorbis codec in an .ogg container.
 
 | Box Name | Type | Description | 
 |-------|--------|--------|


### PR DESCRIPTION
The ogg file type is simply a container. Files using the libopus codec do not work, even thought they are in an ogg container.

for example, say you wanted to convert an mp3 to ogg for use in Sammi.

ffmpeg -i input.mp3 -c:a libopus output.ogg

Will give you a file that appears it should work, it's selectable within SAMMI, however clicking play within Sammi doesn't produce a sound.

If you convert it using

ffmpeg -i input.mp3 -c:a vorbis -strict -2 output.ogg

You also end up with an ogg file type, you can select it in Sammi, but now when you click play it produces the sound.