### PR TITLE
Update swap-red-blue.md

### DIFF
--- a/doc_posts/_commands-number/swap-red-blue.md
+++ b/doc_posts/_commands-number/swap-red-blue.md
@@ -9,12 +9,14 @@ Swaps red and blue value for a color in DEC format and returns its DEC value.
 Useful for converting HTML colors to SAMMI or OBS colors.\
 SAMMI uses BGR colors while OBS uses ABGR colors, instead of RGB colors.
 
+{% include alert.html text="If you have a Hex string (like #1f9250) use [Hex String To Number]({{ "commands/hex-to-number" | relative_url }}) to get a decimal number which you can use to swap red and blue values" type="warning" %}
+
 | Box Name | Type | Description |
 |-------|--------|--------
 | Variable Name | String | Name of the variable containing the color value to swap red and blue. |
 {:class='table table-primary' }
 
-{% include example_public.html src="https://imgur.com/a/ANCuhT3" size="100" title="Converting a hex string to an OBS Color" pastebin="5vSMfiKr" %} 
+{% include example_public.html src="https://imgur.com/a/8CTbOa3" size="100" title="Converting a hex string to an OBS Color" pastebin="8BfSVAC4" %} 
 
 
 

--- a/doc_posts/_commands-number/swap-red-blue.md
+++ b/doc_posts/_commands-number/swap-red-blue.md
@@ -5,16 +5,16 @@ redirect_from:
   - commands/170
 ---
 
-Swaps red and blue value for a color in HEX/DEC format and returns its DEC value.
+Swaps red and blue value for a color in DEC format and returns its DEC value.
 Useful for converting HTML colors to SAMMI or OBS colors.\
-Both SAMMI and OBS uses BGR colors instead of RGB colors.
+SAMMI uses BGR colors while OBS uses ABGR colors, instead of RGB colors.
 
 | Box Name | Type | Description |
 |-------|--------|--------
 | Variable Name | String | Name of the variable containing the color value to swap red and blue. |
 {:class='table table-primary' }
 
-
+{% include example_public.html src="https://imgur.com/a/ANCuhT3" size="100" title="Converting a hex string to an OBS Color" pastebin="5vSMfiKr" %} 
 
 
 

--- a/doc_posts/_commands-number/swap-red-blue.md
+++ b/doc_posts/_commands-number/swap-red-blue.md
@@ -9,7 +9,7 @@ Swaps red and blue value for a color in DEC format and returns its DEC value.
 Useful for converting HTML colors to SAMMI or OBS colors.\
 SAMMI uses BGR colors while OBS uses ABGR colors, instead of RGB colors.
 
-{% include alert.html text="If you have a Hex string (like #1f9250) use [Hex String To Number]({{ "commands/hex-to-number" | relative_url }}) to get a decimal number which you can use to swap red and blue values" type="warning" %}
+{% include alert.html text="If you have a Hex string (like #1f9250) use [Hex String To Number]({{ "commands/number#hexstringtonumber" | relative_url }}) to get a decimal number which you can use to swap red and blue values" type="warning" %}
 
 | Box Name | Type | Description |
 |-------|--------|--------

--- a/doc_posts/_commands-number/swap-red-blue.md
+++ b/doc_posts/_commands-number/swap-red-blue.md
@@ -11,15 +11,11 @@ SAMMI uses BGR colors while OBS uses ABGR colors, instead of RGB colors.
 
 {% include alert.html text="If you have a Hex string (like #1f9250) use [Hex String To Number]({{ "commands/number#hexstringtonumber" | relative_url }}) to get a decimal number which you can use to swap red and blue values" type="warning" %}
 
+{% include alert.html text="As mentioned above, OBS uses ABGR. If you're converting for use in OBS, add the number 4278190080 after conversion to make it work. Check the example below." type="warning" %}
+
 | Box Name | Type | Description |
 |-------|--------|--------
 | Variable Name | String | Name of the variable containing the color value to swap red and blue. |
 {:class='table table-primary' }
 
 {% include example_public.html src="https://imgur.com/a/8CTbOa3" size="100" title="Converting a hex string to an OBS Color" pastebin="8BfSVAC4" %} 
-
-
-
-
-
-


### PR DESCRIPTION
Original Swap Red & Blue states you can swap HEX colors but trying to use Swap Red & Blue on a hex for instance #001122 crashes sammi (with or without the #) Original also mentions OBS uses BGR but OBS uses ABGR and trying to plug a BGR color into OBS produces a JSON string is wrong error. To correct this, you can add 4278190080 to your BGR color after swapping.